### PR TITLE
Fix descender clipping on letters like "g" in sidebar items

### DIFF
--- a/docs/platform-teams/arche.md
+++ b/docs/platform-teams/arche.md
@@ -107,3 +107,9 @@ Arche is the origin and first cause — the primordial source from which all pla
     />
   </div>
 </div>
+
+## Repositories
+
+### AI Context
+
+- **[pt-arche-ai-context](https://github.com/osinfra-io/pt-arche-ai-context)**: Team-level Copilot instructions for `pt-arche-*` repositories

--- a/docs/platform-teams/corpus.md
+++ b/docs/platform-teams/corpus.md
@@ -7,15 +7,19 @@ description: The embodiment of that order — the structural form where networks
 
 Corpus is the embodiment of that order — the structural form where networks, shared services, and core infrastructure take shape, preparing the body that Pneuma will animate. The abstract principles of Logos are translated here into tangible, reliable infrastructure.
 
-- **GCP projects** — CIS-compliant project creation with standard labels
-- **Shared VPC and networking** — Subnets, firewall rules, and network peering
-- **DNS zones** — Cloud DNS management for platform domains
-- **Artifact Registry** — Container image and package storage
-- **GitHub Actions service accounts** — Workload identity for CI/CD pipelines
-- **State buckets** — Encrypted OpenTofu state storage with KMS
+- **GCP projects**: CIS-compliant project creation with standard labels
+- **Shared VPC and networking**: Subnets, firewall rules, and network peering
+- **DNS zones**: Cloud DNS management for platform domains
+- **Artifact Registry**: Container image and package storage
+- **GitHub Actions service accounts**: Workload identity for CI/CD pipelines
+- **State buckets**: Encrypted OpenTofu state storage with KMS
 
 Corpus consumes Logos outputs and provides the foundation for Pneuma workload environments.
 
-## Repository
+## Repositories
 
-- [pt-corpus](https://github.com/osinfra-io/pt-corpus)
+- **[pt-corpus](https://github.com/osinfra-io/pt-corpus)**: OpenTofu configuration for GCP projects, shared VPC and networking, GitHub Actions service accounts, and encrypted state buckets
+
+### AI Context
+
+- **[pt-corpus-ai-context](https://github.com/osinfra-io/pt-corpus-ai-context)**: Team-level Copilot instructions for `pt-corpus-*` repositories

--- a/docs/platform-teams/ekklesia.md
+++ b/docs/platform-teams/ekklesia.md
@@ -7,4 +7,10 @@ description: The assembly of the called-out — where distinct capabilities are 
 
 Ekklesia is the assembly of the called-out — where distinct capabilities are gathered into a unified body, deliberating and acting in concert toward shared platform purpose. This is that assembly.
 
-- **[pt-ekklesia-docs](https://github.com/osinfra-io/pt-ekklesia-docs)** — Platform documentation powered by Docusaurus and deployed via GitHub Pages
+## Repositories
+
+- **[pt-ekklesia-docs](https://github.com/osinfra-io/pt-ekklesia-docs)**: Platform documentation powered by Docusaurus and deployed via GitHub Pages
+
+### AI Context
+
+- **[pt-ekklesia-ai-context](https://github.com/osinfra-io/pt-ekklesia-ai-context)**: Team-level Copilot instructions for `pt-ekklesia-*` repositories

--- a/docs/platform-teams/logos.md
+++ b/docs/platform-teams/logos.md
@@ -7,14 +7,19 @@ description: The foundational principle of order across systems, integrating mul
 
 Logos is the foundational principle of order across systems — integrating multi-provider infrastructure, establishing boundaries, governance, and stable standards for teams to operate autonomously. It is the platform's primordial principle from which all other structure emerges.
 
-- **GCP folder hierarchy** — Environment-scoped folders for sandbox, non-production, and production
-- **Google Identity groups** — Team-based access control groups
-- **GitHub teams and repositories** — Team membership and repo configuration with branch protection
-- **Datadog teams** — Observability team structure
-- **User management** — Centralized identity and access
+- **GCP folder hierarchy**: Environment-scoped folders for sandbox, non-production, and production
+- **Google Identity groups**: Team-based access control groups
+- **GitHub teams and repositories**: Team membership and repo configuration with branch protection
+- **Datadog teams**: Observability team structure
+- **User management**: Centralized identity and access
 
 All downstream platform teams depend on Logos outputs for folder IDs, team data, and identity group references.
 
-## Repository
+## Repositories
 
-- [pt-logos](https://github.com/osinfra-io/pt-logos)
+- **[pt-logos](https://github.com/osinfra-io/pt-logos)**: OpenTofu configuration for GCP folder hierarchy, Google Identity groups, GitHub teams and repositories, and Datadog teams
+
+### AI Context
+
+- **[pt-ai-context](https://github.com/osinfra-io/pt-ai-context)**: Platform-level Copilot instructions applying universally to all `pt-*` repositories
+- **[pt-logos-ai-context](https://github.com/osinfra-io/pt-logos-ai-context)**: Team-level Copilot instructions for `pt-logos-*` repositories

--- a/docs/platform-teams/pneuma.md
+++ b/docs/platform-teams/pneuma.md
@@ -7,15 +7,19 @@ description: The breath of life animating the platform via Kubernetes, orchestra
 
 Pneuma is the breath of life animating the platform via Kubernetes — orchestrating dynamic, self-healing, and scalable services atop the Logos foundation. Where Corpus gives form, Pneuma gives life, transforming infrastructure into workload environments capable of receiving and running application teams.
 
-- **GKE clusters** — Multi-zone Kubernetes clusters with node auto-provisioning
-- **Istio service mesh** — Traffic management, mTLS, and observability
-- **cert-manager** — Automated TLS certificate provisioning via Let's Encrypt
-- **OPA Gatekeeper** — Policy enforcement for Kubernetes resources
-- **Datadog Operator** — Cluster-level monitoring and log collection
+- **GKE clusters**: Multi-zone Kubernetes clusters with node auto-provisioning
+- **Istio service mesh**: Traffic management, mTLS, and observability
+- **cert-manager**: Automated TLS certificate provisioning via Let's Encrypt
+- **OPA Gatekeeper**: Policy enforcement for Kubernetes resources
+- **Datadog Operator**: Cluster-level monitoring and log collection
 
 Pneuma consumes Corpus networking and Logos team data to create fully operational Kubernetes environments.
 
 ## Repositories
 
-- [pt-pneuma](https://github.com/osinfra-io/pt-pneuma)
-- [pt-pneuma-istio-test](https://github.com/osinfra-io/pt-pneuma-istio-test) — Example Istio test application that displays GKE cluster information; deployed as a container image to Google Artifact Registry and run on GKE clusters managed by pt-pneuma
+- **[pt-pneuma](https://github.com/osinfra-io/pt-pneuma)**: OpenTofu configuration for GKE clusters and Kubernetes add-ons (cert-manager, Istio, OPA Gatekeeper, Datadog Operator)
+- **[pt-pneuma-istio-test](https://github.com/osinfra-io/pt-pneuma-istio-test)**: Example Istio test application that displays GKE cluster information; deployed as a container image to Google Artifact Registry and run on GKE clusters managed by pt-pneuma
+
+### AI Context
+
+- **[pt-pneuma-ai-context](https://github.com/osinfra-io/pt-pneuma-ai-context)**: Team-level Copilot instructions for `pt-pneuma-*` repositories

--- a/docs/platform-teams/techne.md
+++ b/docs/platform-teams/techne.md
@@ -7,8 +7,14 @@ description: The practiced art of making — the disciplined craft through which
 
 Techne is the practiced art of making — the disciplined craft through which raw materials of infrastructure are shaped into purposeful, refined platform instruments.
 
-- **[pt-techne-opentofu-workflows](https://github.com/osinfra-io/pt-techne-opentofu-workflows)** — Reusable GitHub Actions called workflows for OpenTofu deployments (OIDC auth, state encryption, job summaries)
-- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)** — Custom pre-commit hooks for IaC validation
-- **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)** — GitHub Codespace for standardized OpenTofu development environments
-- **[pt-techne-misc-workflows](https://github.com/osinfra-io/pt-techne-misc-workflows)** — Miscellaneous reusable workflows
-- **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)** — Local development environment setup
+## Repositories
+
+- **[pt-techne-opentofu-workflows](https://github.com/osinfra-io/pt-techne-opentofu-workflows)**: Reusable GitHub Actions called workflows for OpenTofu deployments (OIDC auth, state encryption, job summaries)
+- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Custom pre-commit hooks for IaC validation
+- **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)**: GitHub Codespace for standardized OpenTofu development environments
+- **[pt-techne-misc-workflows](https://github.com/osinfra-io/pt-techne-misc-workflows)**: Miscellaneous reusable workflows
+- **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)**: Local development environment setup
+
+### AI Context
+
+- **[pt-techne-ai-context](https://github.com/osinfra-io/pt-techne-ai-context)**: Team-level Copilot instructions for `pt-techne-*` repositories

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -81,3 +81,8 @@
 .navbar__search-input {
   border-radius: 4px !important;
 }
+
+/* Fix descender clipping on letters like "g" in sidebar items */
+.menu__link {
+  line-height: 1.5;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,5 +84,5 @@
 
 /* Fix descender clipping on letters like "g" in sidebar items */
 .menu__link {
-  line-height: 1.5;
+  line-height: 1.35;
 }


### PR DESCRIPTION
The letter "g" (and other descender letters like p, q, y) was being slightly clipped at the bottom in the sidebar — visible on pages like "Teams" where "Logos" and "Stream-Aligned Teams" appear in the nav.

The root cause is Docusaurus's default tight `line-height` on `.menu__link` elements. Increasing it to `1.5` gives descenders enough vertical space to render fully.

**Change:** Added `line-height: 1.5` to `.menu__link` in `src/css/custom.css`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing for menu/sidebar links to prevent descender clipping and improve readability.

* **Documentation**
  * Rewrote several team docs to use colon-based list formatting and renamed “Repository” sections to “Repositories.”
  * Expanded several repository descriptions with clearer roles (e.g., infra/config responsibilities).
  * Added “AI Context” subsections referencing team-level Copilot instruction repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->