### PR TITLE
Restore original UI invoke instructions with example prompt code block

### DIFF
--- a/docs/platform-teams/arche/module-development.md
+++ b/docs/platform-teams/arche/module-development.md
@@ -16,7 +16,11 @@ The **Arche Module Agent** is a GitHub Copilot coding agent that creates new `pt
 
 ### How to invoke it
 
-Open [GitHub Copilot](https://github.com/copilot), type `/agent`, and select **Arche Module Agent** from the menu.
+Open [GitHub Copilot](https://github.com/copilot) and ask it to use the Arche Module Agent from the `pt-arche-child-module-template` repository:
+
+```none
+Use the Arche Module Agent in osinfra-io/pt-arche-child-module-template to create a new module.
+```
 
 The agent takes it from there.
 

--- a/docs/platform-teams/arche/module-development.md
+++ b/docs/platform-teams/arche/module-development.md
@@ -24,7 +24,7 @@ Use the Arche Module Agent in osinfra-io/pt-arche-child-module-template to creat
 
 The agent takes it from there.
 
-:::tip Using the GitHub Copilot CLI
+:::tip Prefer the CLI
 
 Clone the template repo and run the Copilot CLI from within it — then type `/agent` and select **Arche Module Agent** from the menu:
 

--- a/docs/platform-teams/arche/module-development.md
+++ b/docs/platform-teams/arche/module-development.md
@@ -24,7 +24,7 @@ Use the Arche Module Agent in osinfra-io/pt-arche-child-module-template to creat
 
 The agent takes it from there.
 
-:::tip Prefer the CLI
+:::tip Prefer the CLI?
 
 Clone the template repo and run the Copilot CLI from within it — then type `/agent` and select **Arche Module Agent** from the menu:
 

--- a/docs/stream-aligned-teams/getting-started.md
+++ b/docs/stream-aligned-teams/getting-started.md
@@ -25,7 +25,7 @@ Use the Logos Agent in osinfra-io/pt-logos to onboard my team.
 
 The agent will look up your identity, check whether you already exist on the platform, and walk you through the rest.
 
-:::tip Using the GitHub Copilot CLI
+:::tip Prefer the CLI
 
 Clone the repo and run the Copilot CLI from within it — then type `/agent` and select **Logos Agent** from the menu:
 

--- a/docs/stream-aligned-teams/getting-started.md
+++ b/docs/stream-aligned-teams/getting-started.md
@@ -25,7 +25,7 @@ Use the Logos Agent in osinfra-io/pt-logos to onboard my team.
 
 The agent will look up your identity, check whether you already exist on the platform, and walk you through the rest.
 
-:::tip Prefer the CLI
+:::tip Prefer the CLI?
 
 Clone the repo and run the Copilot CLI from within it — then type `/agent` and select **Logos Agent** from the menu:
 

--- a/docs/stream-aligned-teams/getting-started.md
+++ b/docs/stream-aligned-teams/getting-started.md
@@ -17,7 +17,11 @@ The Logos Agent manages everything a stream-aligned team needs on the platform: 
 
 ### How to invoke it
 
-Open [GitHub Copilot](https://github.com/copilot), type `/agent`, and select **Logos Agent** from the menu.
+Open [GitHub Copilot](https://github.com/copilot) and ask it to use the Logos Agent from the `pt-logos` repository:
+
+```none
+Use the Logos Agent in osinfra-io/pt-logos to onboard my team.
+```
 
 The agent will look up your identity, check whether you already exist on the platform, and walk you through the rest.
 


### PR DESCRIPTION
Restores the original "How to invoke it" section on both agent pages — the UI invoke instructions were changed when CLI instructions were added. This PR keeps both, side by side:

- **UI**: prose explaining to open GitHub Copilot and use the agent, with an example prompt code block
- **CLI**: `:::tip` admonition showing `git clone` + `gh copilot` — additive, not replacing

**Files changed:**
- `docs/stream-aligned-teams/getting-started.md`
- `docs/platform-teams/arche/module-development.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for invoking GitHub Copilot agents: users can now prompt Copilot to use the Arche Module Agent or the Logos Agent directly (sample prompts provided) instead of using menu selection.
  * Renamed the “Using the GitHub Copilot CLI” tip to “Prefer the CLI?”; CLI workflow and steps remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->