### PR TITLE
Add DDD content and enabling teams to docs site

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,9 +48,9 @@ Every team (platform or stream-aligned) gets a folder, not a flat page. This all
 
 ## Architecture Decision Records
 
-ADRs live at the bottom of the relevant documentation page under a `## Architecture Decision Records` heading — not in separate files. Each ADR is a `###` subsection with a descriptive title.
+ADRs live at the bottom of the relevant documentation page under a `## Architecture Decision Records` heading — not in separate files. This must always be the **last `##` heading on the page** — no sections follow it. Each ADR is a `###` subsection with a descriptive title.
 
-Add a `:::tip` admonition near the top of the page (after the intro paragraph) to signal that ADRs are present:
+If a page contains ADRs, add a `:::tip` admonition immediately after the opening intro content (paragraphs and any bullet list), before the first `##` section heading:
 
 ```md
 :::tip Architecture Decision Records

--- a/docs/enabling-teams/index.md
+++ b/docs/enabling-teams/index.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: Enabling Teams
+description: Enabling teams provide specialist expertise to help both platform and stream-aligned teams adopt new capabilities and overcome obstacles without creating long-term dependencies.
+---
+
+import Card from '@site/src/components/Card';
+import CardGrid from '@site/src/components/CardGrid';
+
+# Enabling Teams
+
+Enabling teams provide specialist expertise on a temporary, collaborative basis — helping both platform and stream-aligned teams overcome obstacles, adopt new practices, and grow their own capabilities. Unlike platform teams, enabling teams do not own long-running services; they teach, coach, and uplift.
+
+## Teams
+
+<CardGrid>
+  <Card item={{ icon: '🛡️', title: 'Soteria', note: 'The keeper of safety and preservation — embedding security practices, threat modeling, and compliance into the flow of every team rather than treating security as a gate.', link: '/enabling-teams/soteria', linkText: 'Learn more →' }} />
+  <Card item={{ icon: '⚖️', title: 'Sophrosyne', note: 'The virtue of soundness and self-discipline — helping teams define reliability targets, build observability, and sustain the health of the platform through SLOs and incident response.', link: '/enabling-teams/sophrosyne', linkText: 'Learn more →' }} />
+</CardGrid>

--- a/docs/enabling-teams/sophrosyne/index.md
+++ b/docs/enabling-teams/sophrosyne/index.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Sophrosyne
+description: The virtue of soundness and self-discipline — helping teams define reliability targets, build observability, and sustain the health of the platform.
+---
+
+# Sophrosyne
+
+The virtue of soundness and self-discipline — helping teams define reliability targets, build observability, and sustain the health of the platform through SLOs, incident response, and a culture of reliability.

--- a/docs/enabling-teams/soteria/index.md
+++ b/docs/enabling-teams/soteria/index.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Soteria
+description: The keeper of safety and preservation — embedding security practices, threat modeling, and compliance into the flow of every team.
+---
+
+# Soteria
+
+The keeper of safety and preservation — embedding security practices, threat modeling, and compliance controls into the flow of every team rather than treating security as a gate.

--- a/docs/platform-teams/arche/core-helpers.md
+++ b/docs/platform-teams/arche/core-helpers.md
@@ -8,6 +8,10 @@ sidebar_label: Core Helpers
 
 Without it, every module would need to independently parse the OpenTofu workspace name, compute environment labels, read Logos remote state, and validate cost center and data classification. Core helpers does all of that once, in one place.
 
+## Domain-Driven Design
+
+In DDD terms, `pt-arche-core-helpers` is the platform's **Anti-Corruption Layer (ACL)**. It stands between raw OpenTofu workspace state and every module that needs deployment context. All environment strings, labels, team data, and folder IDs flow through it — no module accesses these values independently. This boundary prevents environment-specific logic from leaking into module implementations and ensures that adding a new environment or team requires no changes outside Logos and core-helpers.
+
 ## Two variants
 
 The module ships two variants consumed via different source paths:

--- a/docs/platform-teams/arche/google-cloud.md
+++ b/docs/platform-teams/arche/google-cloud.md
@@ -8,6 +8,22 @@ import ModuleCard from '@site/src/components/ModuleCard';
 
 GCP infrastructure modules covering project governance, networking, compute, storage, and Datadog observability integration. All modules consume `pt-arche-core-helpers` for environment detection, labels, and team data.
 
+## Domain-Driven Design
+
+These modules form the **Google Cloud** bounded context within Arche. The **Domain Served** column identifies which platform domain primarily consumes each module.
+
+| Module | Domain Served | Purpose |
+|---|---|---|
+| `pt-arche-core-helpers` | All | Workspace parsing, labels, team data, environment detection |
+| `pt-arche-google-project` | Corpus | CIS-compliant GCP project with billing, APIs, and monitoring |
+| `pt-arche-google-network` | Corpus | Shared VPC with subnets, firewall rules, Cloud NAT, DNS |
+| `pt-arche-google-kubernetes-engine` | Pneuma | GKE cluster with Workload Identity, KMS, CIS hardening, Fleet |
+| `pt-arche-google-storage-bucket` | Corpus | GCS bucket with CMEK, uniform access, versioning |
+| `pt-arche-google-cloud-sql` | Stream-aligned teams | Cloud SQL with HA, backups, private IP |
+| `pt-arche-datadog-google-integration` | Corpus | Datadog GCP integration via Workload Identity, Pub/Sub, Cloud Asset |
+
+## Modules
+
 <div className="row">
   <div className="col col--4 margin-bottom--lg">
     <ModuleCard

--- a/docs/platform-teams/arche/index.md
+++ b/docs/platform-teams/arche/index.md
@@ -7,7 +7,7 @@ description: The origin and first cause — the primordial source from which all
 
 Arche is the origin and first cause — the primordial source from which all platform foundations draw their initial form and essential nature. Nothing above it exists without it.
 
-Arche operates as an inner-source shared kernel: versioned OpenTofu modules published on GitHub, consumed by Logos, Corpus, and Pneuma as pinned dependencies. All modules build on `pt-arche-core-helpers` for environment detection, standard labels, and team data. See the [shared kernel ADR](#arche-as-an-inner-source-shared-kernel) for the rationale behind this design.
+Arche operates as an inner-source shared kernel: versioned OpenTofu modules published on GitHub, consumed by all teams as pinned dependencies. All modules build on `pt-arche-core-helpers` for environment detection, standard labels, and team data. See the [shared kernel ADR](#arche-as-an-inner-source-shared-kernel) for the rationale behind this design.
 
 - **[Core Helpers](./core-helpers.md)**: Foundational module providing workspace parsing, standard labels, and Logos integration — consumed by every other `pt-arche-*` module
 - **[Module Development](./module-development.md)**: Copilot agent and skeleton template for creating new `pt-arche-*` modules
@@ -19,6 +19,35 @@ Arche operates as an inner-source shared kernel: versioned OpenTofu modules publ
 This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
 
 :::
+
+## Domain-Driven Design
+
+Arche operates as the platform's **Shared Kernel** in the [context map](/platform-teams#context-map) — versioned OpenTofu modules consumed by all teams as pinned dependencies.
+
+**Ubiquitous Language:** module, source, ref, version, label, environment, workspace, helpers
+
+### Bounded Contexts
+
+Arche is decomposed into two bounded contexts that map directly to the infrastructure layer each module targets:
+
+| Bounded Context | Modules | Consumed By |
+|---|---|---|
+| [Google Cloud](./google-cloud.md) | project, network, GKE, storage, Cloud SQL, Datadog integration | Corpus, Pneuma, stream-aligned teams |
+| [Kubernetes](./kubernetes.md) | Istio, cert-manager, Datadog Operator, OPA Gatekeeper | Pneuma |
+
+### Anti-Corruption Layer
+
+[`pt-arche-core-helpers`](./core-helpers.md) is the foundational module that every other module builds on. It is the only module that reads OpenTofu workspace state directly — translating raw workspace names (e.g., `main-production`, `us-east1-b-sandbox`) into structured context all other modules consume. No module hardcodes environment strings, labels, or team data.
+
+### Core Invariant
+
+Every module `ref` must point to a post-merge commit SHA on `main` — never a branch name or semver tag. This makes every deployment reproducible and auditable.
+
+## Repositories
+
+### AI Context
+
+- **[pt-arche-ai-context](https://github.com/osinfra-io/pt-arche-ai-context)**: Team-level Copilot instructions for `pt-arche-*` repositories
 
 ## Architecture Decision Records
 
@@ -35,7 +64,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 #### Context and Problem Statement
 
-The platform needs reusable infrastructure patterns — CIS-compliant GCP projects, shared VPC networks, GKE clusters, Istio, cert-manager, OPA Gatekeeper, and Datadog — consumed consistently by Logos, Corpus, and Pneuma. Without a shared approach, each domain would implement these patterns independently, leading to drift, duplicated effort, and inconsistent security posture.
+The platform needs reusable infrastructure patterns — CIS-compliant GCP projects, shared VPC networks, GKE clusters, Istio, cert-manager, OPA Gatekeeper, and Datadog — consumed consistently by all platform teams. Without a shared approach, each team would implement these patterns independently, leading to drift, duplicated effort, and inconsistent security posture.
 
 The modules also need to evolve independently of the domains that consume them. A bug fix in the GKE module should not require changes to Corpus or Pneuma source code — only a version pin update.
 
@@ -54,7 +83,7 @@ Modules are decomposed into two bounded contexts reflecting their infrastructure
 
 This decomposition maps directly to the deployment layers in Corpus (GCP) and Pneuma (Kubernetes), making it clear which modules each domain consumes.
 
-The same pattern is applied in [Techne's shared kernel](/platform-teams/techne#techne-as-an-inner-source-shared-kernel) for shared platform tooling and [Ekklesia's shared kernel](/platform-teams/ekklesia#ekklesia-as-an-inner-source-shared-kernel) for platform documentation — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
+A similar inner-source contribution model is used by [Techne](/platform-teams/techne#techne-as-a-conformist-platform-tooling-layer) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type and DDD relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Alternatives Considered
 
@@ -68,9 +97,3 @@ The same pattern is applied in [Techne's shared kernel](/platform-teams/techne#t
 - Security and compliance improvements propagate to all consumers on their next module version bump
 - New modules follow an established template (`pt-arche-child-module-template`) and are registered in pt-logos
 - Consumers must coordinate module upgrades across domains when breaking changes are released — mitigated by semver signalling and the upgrade order convention (core-helpers → other arche modules → consumers)
-
-## Repositories
-
-### AI Context
-
-- **[pt-arche-ai-context](https://github.com/osinfra-io/pt-arche-ai-context)**: Team-level Copilot instructions for `pt-arche-*` repositories

--- a/docs/platform-teams/arche/kubernetes.md
+++ b/docs/platform-teams/arche/kubernetes.md
@@ -8,6 +8,19 @@ import ModuleCard from '@site/src/components/ModuleCard';
 
 Kubernetes add-on modules for service mesh, certificate management, policy enforcement, and cluster-level observability. These modules run on the GKE clusters provisioned by Pneuma.
 
+## Domain-Driven Design
+
+These modules form the **Kubernetes** bounded context within Arche. All are deployed by Pneuma onto GKE clusters.
+
+| Module | Domain Served | Purpose |
+|---|---|---|
+| `pt-arche-kubernetes-istio` | Pneuma | Istio service mesh with ingress gateway and Cloud Armor WAF |
+| `pt-arche-kubernetes-cert-manager` | Pneuma | cert-manager with Let's Encrypt ACME issuance |
+| `pt-arche-kubernetes-datadog-operator` | Pneuma | Datadog Operator and Agent DaemonSet |
+| `pt-arche-kubernetes-opa-gatekeeper` | Pneuma | OPA Gatekeeper with constraint templates |
+
+## Modules
+
 <div className="row">
   <div className="col col--4 margin-bottom--lg">
     <ModuleCard

--- a/docs/platform-teams/arche/module-development.md
+++ b/docs/platform-teams/arche/module-development.md
@@ -81,6 +81,26 @@ tests/
 
 The `helpers.tofu` in the skeleton is pre-pinned to the current `pt-arche-core-helpers` SHA so the new module starts with an up-to-date foundational dependency.
 
+## Domain-Driven Design
+
+Arche modules follow a two-sided contract between module authors and consumers.
+
+**Authors** tag releases with semver after merging to `main`. The release workflow generates notes and publishes automatically:
+
+```none
+git tag v1.2.3 && git push origin v1.2.3
+```
+
+**Consumers** never reference semver tags or branch names as `ref` values — they always pin to the post-merge commit SHA on `main` with an inline version comment:
+
+```hcl
+module "google_project" {
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=<40-char-sha>"  # v1.2.3
+}
+```
+
+The SHA must come from after the squash merge lands on `main`, not from the PR branch tip. Branch SHAs are unstable and can be rewritten; `main` SHAs are permanent.
+
 ## Repository naming convention
 
 | Infrastructure type | Pattern | Example |

--- a/docs/platform-teams/corpus/ci-cd-enablement.md
+++ b/docs/platform-teams/corpus/ci-cd-enablement.md
@@ -16,6 +16,16 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `service-account` | A GCP service account created per repository and environment for GitHub Actions workloads |
+| `workload-identity-pool` | A Workload Identity Federation pool that maps GitHub OIDC tokens to GCP service accounts — no static credentials |
+| `workload-identity-provider` | An OIDC provider within the pool, scoped to a specific GitHub org and repository |
+| `artifact-registry` | A container image and package registry scoped per team, consumed by GKE workloads |
+| `state-bucket` | An encrypted GCS bucket per repository per environment used as the OpenTofu remote backend, protected by a per-environment KMS key |
+
 ## Architecture Decision Records
 
 ### Keyless Authentication via Workload Identity Federation

--- a/docs/platform-teams/corpus/index.md
+++ b/docs/platform-teams/corpus/index.md
@@ -13,6 +13,24 @@ Corpus is the embodiment of that order — the structural form where networks, s
 
 Corpus consumes Logos outputs and provides the foundation for Pneuma workload environments.
 
+## Domain-Driven Design
+
+Corpus is a downstream **Customer/Supplier** consumer of Logos, and an upstream supplier to Pneuma in the platform's [context map](/platform-teams#context-map).
+
+**Ubiquitous Language:** project, CIS benchmark, subnet, shared VPC, firewall rule, DNS zone, workload identity, artifact registry, state bucket
+
+### Downstream Interfaces
+
+| Output | Consumed By | Via | Description |
+|---|---|---|---|
+| Shared VPC and subnet self-links | Pneuma | `module.core_helpers.teams` | GKE cluster node and pod network attachment |
+| Project IDs | Pneuma | `module.core_helpers.teams` | Cluster placement and Workload Identity binding |
+| Networking CIDRs | Pneuma | `module.core_helpers.teams` | Node, pod, and service IP range allocation |
+
+### Core Invariant
+
+Every GCP project is CIS-compliant at creation — there is no non-compliant state.
+
 ## Repositories
 
 - **[pt-corpus](https://github.com/osinfra-io/pt-corpus)**: OpenTofu configuration for GCP projects, shared VPC and networking, GitHub Actions service accounts, and encrypted state buckets

--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -24,6 +24,16 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `shared-vpc` | A VPC host project network shared across all team projects in an environment |
+| `subnet` | A regional subnetwork with primary node CIDR, pod secondary range, and service secondary range |
+| `firewall-rule` | Network-level traffic controls applied to the shared VPC |
+| `dns-zone` | A Cloud DNS managed zone for a platform domain (e.g., `osinfra.io`) |
+| `cloud-nat` | Managed NAT for private nodes to reach the internet without public IPs |
+
 ## IP Address Management
 
 The `10.0.0.0/8` RFC 1918 space is divided into four `/10` blocks, each supporting up to 30 isolated GKE clusters. VPCs use the same address space across sandbox, non-production, and production environments, with each environment isolated to its own project. All CIDR ranges are defined in [pt-logos](https://github.com/osinfra-io/pt-logos) and flow through [pt-corpus](https://github.com/osinfra-io/pt-corpus) to [pt-pneuma](https://github.com/osinfra-io/pt-pneuma).

--- a/docs/platform-teams/corpus/projects.md
+++ b/docs/platform-teams/corpus/projects.md
@@ -16,6 +16,16 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `gcp-project` | A GCP project created under the correct environment folder with billing and APIs enabled |
+| `cis-policy` | A set of CIS GCP Foundation Benchmark controls applied at project creation (audit logging, OS Login, no default VPC) |
+| `billing-budget` | Automatic spending alerts at 50%, 75%, and 100% of threshold on every project |
+| `labels` | Standard label set derived from `module.core_helpers.labels` — always includes `env`, `team`, `managed-by` |
+| `monitoring-channel` | Cloud Monitoring notification channels for budget and infrastructure change alerts |
+
 ## Architecture Decision Records
 
 ### CIS GCP Foundation Benchmark Compliance by Default

--- a/docs/platform-teams/ekklesia/documentation.md
+++ b/docs/platform-teams/ekklesia/documentation.md
@@ -6,6 +6,14 @@ sidebar_label: Documentation
 
 [`pt-ekklesia-docs`](https://github.com/osinfra-io/pt-ekklesia-docs) is the platform documentation site, published at **[docs.osinfra.io](https://docs.osinfra.io)**.
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `doc-page` | A Markdown page in the Docusaurus site, organized by team and bounded context |
+| `adr` | An Architecture Decision Record embedded in a doc page, capturing context, decision, alternatives, and consequences |
+| `sidebar` | The Docusaurus navigation structure reflecting the DDD model |
+
 ## Tech stack
 
 Built on [Docusaurus 3](https://docusaurus.io/) with the following features enabled:

--- a/docs/platform-teams/ekklesia/index.md
+++ b/docs/platform-teams/ekklesia/index.md
@@ -7,7 +7,7 @@ description: The assembly of the called-out — where distinct capabilities are 
 
 Ekklesia is the assembly of the called-out — where distinct capabilities are gathered into a unified body, deliberating and acting in concert toward shared platform purpose. This is that assembly.
 
-Ekklesia operates as an inner-source shared kernel: a single centralized documentation site where every platform team contributes, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [shared kernel ADR](#ekklesia-as-an-inner-source-shared-kernel) for the rationale.
+Ekklesia operates as the platform's shared knowledge domain: a single centralized documentation site where every platform team contributes, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [knowledge domain ADR](#ekklesia-as-the-platforms-shared-knowledge-domain) for the rationale.
 
 :::tip Architecture Decision Records
 
@@ -15,9 +15,27 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+Ekklesia operates as the platform's **Shared Knowledge Domain** in the [context map](/platform-teams#context-map) — all teams contribute documentation here and consume it as the canonical reference for platform knowledge.
+
+**Ubiquitous Language:** page, architecture decision record, sidebar, contributor
+
+### Core Invariant
+
+When platform behaviour changes, the relevant doc page is updated in the same PR.
+
+## Repositories
+
+- **[pt-ekklesia-docs](https://github.com/osinfra-io/pt-ekklesia-docs)**: Platform documentation site powered by Docusaurus, published at [docs.osinfra.io](https://docs.osinfra.io) — see [Documentation](./documentation.md)
+
+### AI Context
+
+- **[pt-ekklesia-ai-context](https://github.com/osinfra-io/pt-ekklesia-ai-context)**: Team-level Copilot instructions for `pt-ekklesia-*` repositories
+
 ## Architecture Decision Records
 
-### Ekklesia as an Inner-Source Shared Kernel
+### Ekklesia as the Platform's Shared Knowledge Domain
 
 <table>
   <thead>
@@ -32,7 +50,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 Platform knowledge — architecture decisions, module usage, deployment patterns, operational guides — is spread across multiple teams and repositories. Without a shared home, documentation lives in README files that are hard to navigate, per-team wikis that fall out of sync, or not at all. Engineers must hunt across repositories to understand how the platform fits together.
 
-This follows the same pattern as [Arche's shared kernel](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Techne's shared kernel](/platform-teams/techne#techne-as-an-inner-source-shared-kernel) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions workflows and tooling; Ekklesia shares documentation.
+This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Techne](/platform-teams/techne#techne-as-a-conformist-platform-tooling-layer) — the difference is artifact type and DDD relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions workflows and tooling as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Decision
 
@@ -52,12 +70,3 @@ Operate a single Docusaurus site (`pt-ekklesia-docs`) as the canonical platform 
 - Platform knowledge has a single discoverable home for engineers and stakeholders
 - Documentation changes go through the same review process as code
 - All teams share responsibility for keeping their sections accurate — no single team owns the whole site
-
-## Repositories
-
-- **[Documentation](./documentation.md)**: Platform documentation site powered by Docusaurus, published at [docs.osinfra.io](https://docs.osinfra.io)
-- **[pt-ekklesia-docs](https://github.com/osinfra-io/pt-ekklesia-docs)**: Platform documentation powered by Docusaurus and deployed via GitHub Pages
-
-### AI Context
-
-- **[pt-ekklesia-ai-context](https://github.com/osinfra-io/pt-ekklesia-ai-context)**: Team-level Copilot instructions for `pt-ekklesia-*` repositories

--- a/docs/platform-teams/index.md
+++ b/docs/platform-teams/index.md
@@ -8,7 +8,7 @@ import CardGrid from '@site/src/components/CardGrid';
 
 # Platform Teams
 
-Platform teams provide the foundational infrastructure and tooling that stream-aligned teams depend on. Each team owns a distinct layer of the platform, deployed in the following order:
+Platform teams provide the foundational infrastructure and tooling that stream-aligned teams depend on. Each team owns a distinct bounded domain within the platform.
 
 <CardGrid>
   <Card item={{ icon: '🏛️', title: 'Logos', note: 'The foundational principle of order across systems — integrating multi-provider infrastructure, establishing boundaries, governance, and stable standards for teams to operate autonomously.', link: '/platform-teams/logos', linkText: 'Learn more →' }} />
@@ -19,3 +19,32 @@ Platform teams provide the foundational infrastructure and tooling that stream-a
   <Card item={{ icon: '🔐', title: 'Kryptos', note: 'The hidden foundation of platform security — managing cryptographic primitives, secrets infrastructure, and security controls that underpin all teams on the platform.', link: '/platform-teams/kryptos', linkText: 'Learn more →' }} />
   <Card item={{ icon: '🛠️', title: 'Techne', note: 'The practiced art of making — the disciplined craft through which raw materials of infrastructure are shaped into purposeful, refined platform instruments.', link: '/platform-teams/techne', linkText: 'Learn more →' }} />
 </CardGrid>
+
+## Domain-Driven Design
+
+The platform is modeled using [Domain-Driven Design](https://martinfowler.com/bliki/DomainDrivenDesign.html) — each team owns a bounded domain with explicit upstream/downstream relationships.
+
+### Context Map
+
+The primary flow is a **Customer/Supplier** chain — Logos supplies team and identity data to Corpus, which supplies networking and project infrastructure to Pneuma.
+
+```mermaid
+flowchart TD
+    Arche["🧱 Arche (Shared Kernel)"]
+    Techne["🛠️ Techne (Conformist)"]
+    Ekklesia["📖 Ekklesia (Knowledge)"]
+    Kryptos["🔐 Kryptos"]
+    AllTeams(["All Teams"])
+
+    subgraph sc ["Infrastructure Supply Chain"]
+        Logos["🏛️ Logos"] -->|"Customer/Supplier"| Corpus["🌐 Corpus"]
+        Corpus -->|"Customer/Supplier"| Pneuma["☸️ Pneuma"]
+    end
+
+    Arche ==>|"Shared Kernel"| sc
+    Techne -.->|"Conformist"| sc
+    Ekklesia -.->|"Knowledge"| sc
+
+    Pneuma -->|"Customer/Supplier"| AllTeams
+    Kryptos -->|"Customer/Supplier"| AllTeams
+```

--- a/docs/platform-teams/index.md
+++ b/docs/platform-teams/index.md
@@ -45,6 +45,7 @@ flowchart TD
     Techne -.->|"Conformist"| sc
     Ekklesia -.->|"Knowledge"| sc
 
+    Pneuma -->|"Customer/Supplier"| Kryptos
     Pneuma -->|"Customer/Supplier"| AllTeams
     Kryptos -->|"Customer/Supplier"| AllTeams
 ```

--- a/docs/platform-teams/kryptos/index.md
+++ b/docs/platform-teams/kryptos/index.md
@@ -6,3 +6,15 @@ description: The hidden foundation of platform security — managing cryptograph
 # Kryptos
 
 The hidden foundation of platform security — managing cryptographic primitives, secrets infrastructure, and security controls that underpin all teams on the platform.
+
+## Domain-Driven Design
+
+Kryptos is a downstream **Customer/Supplier** consumer of Pneuma (runs OpenBao on Pneuma-managed clusters) and an upstream supplier of secrets management to all teams in the [context map](/platform-teams#context-map).
+
+## Repositories
+
+- **[pt-kryptos](https://github.com/osinfra-io/pt-kryptos)**: Secrets infrastructure and cryptographic primitives — OpenBao deployment and platform security controls
+
+### AI Context
+
+- **[pt-kryptos-ai-context](https://github.com/osinfra-io/pt-kryptos-ai-context)**: Team-level Copilot instructions for `pt-kryptos-*` repositories

--- a/docs/platform-teams/logos/identity-access.md
+++ b/docs/platform-teams/logos/identity-access.md
@@ -9,3 +9,11 @@ Logos manages centralized identity and access control for the platform. Google I
 - **Team identity groups**: Three standard groups per team (admin, reader, writer) controlling access to team GCP resources, with membership managed as code
 - **GKE security groups**: An organization-wide security group used for Kubernetes RBAC across all GKE clusters; team identity groups are nested as members
 - **Billing users group**: An organization-wide group that grants the billing user IAM role, used by team service accounts that need to associate projects with the billing account
+
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `identity-group` | A Google Identity group scoped to a team and environment (e.g., `pt-corpus-admins`) |
+| `user` | A platform user provisioned into one or more identity groups |
+| `iam-binding` | A mapping of an identity group to a GCP role at a resource scope |

--- a/docs/platform-teams/logos/index.md
+++ b/docs/platform-teams/logos/index.md
@@ -12,7 +12,24 @@ Logos is the foundational principle of order across systems — integrating mult
 - **[Team Topology](./team-topology.md)**: GitHub teams and repositories, Datadog teams, and branch protection
 - **[SaaS Governance](./saas-governance.md)**: GitHub and Datadog organization-level settings and policies
 
-All downstream platform teams depend on Logos outputs for folder IDs, team data, and identity group references.
+Corpus depends directly on Logos outputs. All other infrastructure domains consume Logos data transitively via the [Arche Shared Kernel](/platform-teams/arche).
+
+## Domain-Driven Design
+
+Logos is the upstream **Customer/Supplier** to Corpus in the platform's [context map](/platform-teams#context-map).
+
+**Ubiquitous Language:** organization, environment, folder, identity group, team, repository, membership, branch protection
+
+### Downstream Interfaces
+
+| Output | Consumed By | Via | Description |
+|---|---|---|---|
+| `environment_folder_id` | Corpus | `module.core_helpers` | Places projects in the correct environment folder |
+| `teams` | Corpus | `module.core_helpers.teams` | Team data map — project names, folder IDs, and group emails |
+
+### Core Invariant
+
+Every team definition produces exactly one set of GCP, GitHub, and Datadog resources.
 
 ## Repositories
 

--- a/docs/platform-teams/logos/resource-hierarchy.md
+++ b/docs/platform-teams/logos/resource-hierarchy.md
@@ -10,3 +10,11 @@ Logos defines the GCP folder hierarchy that organizes all platform infrastructur
 - **Folder IAM**: Corpus service account groups are granted browser, project creator, and XPN admin roles on environment folders, enabling Corpus to discover resources and create projects in the correct folder
 - **Billing budgets**: A monthly budget with threshold alerts is created per team folder
 - **Folder IDs**: Exposed as outputs and consumed downstream by Corpus via `module.core_helpers.environment_folder_id`
+
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `organization` | The GCP organization root — the top-level billing and IAM boundary |
+| `environment-folder` | One folder per environment: `sandbox`, `non-production`, `production` |
+| `folder-iam-policy` | IAM bindings applied at the folder level, inherited by all child projects |

--- a/docs/platform-teams/logos/team-topology.md
+++ b/docs/platform-teams/logos/team-topology.md
@@ -13,6 +13,16 @@ Logos codifies the team structure that all platform tooling — GitHub, GCP, and
 - **GitHub repositories**: Repositories are registered in pt-logos and provisioned with standard settings — squash-only merges, repository rulesets enforcing PR reviews and signed commits, Datadog webhooks, and standard repository files (release notes config, security policy)
 - **Datadog teams**: Observability team structure mirrors GitHub teams; each team gets a service account with a per-team API key and app key stored as GitHub Actions secrets in that team's repositories
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `team` | A platform or stream-aligned team with a name, type, and member list |
+| `github-team` | A GitHub team mirroring the Logos team — controls repo access |
+| `repository` | A GitHub repository registered in Logos with standard settings and branch protection |
+| `branch-protection` | Rules applied to default branch: required reviews, status checks, no force push |
+| `datadog-team` | An observability team in Datadog mirroring the Logos team — owns dashboards and monitors |
+
 ## Team Configuration Schema
 
 Each team is defined as an entry in the `teams` map inside a `.tfvars` file under `teams/`. The schema below documents every available field — click any object or map to expand its properties.

--- a/docs/platform-teams/pneuma/certificate-management.md
+++ b/docs/platform-teams/pneuma/certificate-management.md
@@ -9,3 +9,12 @@ cert-manager manages all certificate issuance within the platform, acting as the
 - **Self-signed root CA**: A self-signed root certificate is generated in the main workspace and used as the trust anchor for the entire cluster. This root cert and key are passed to each regional workspace.
 - **istio-csr**: The cert-manager Istio Certificate Signing Request agent replaces istiod's built-in Citadel CA — the component responsible for signing certificate signing requests (CSRs) from Envoy sidecars. All workload mTLS certificates are signed by cert-manager through this integration; istiod continues to handle config distribution, service discovery, and sidecar injection as normal.
 - **Automatic rotation**: cert-manager handles certificate issuance and rotation for all mesh workloads without manual intervention
+
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `cluster-issuer` | A cluster-scoped ACME issuer configured for Let's Encrypt (staging and production) |
+| `certificate` | A TLS certificate resource managed by cert-manager, backed by a Kubernetes Secret |
+| `acme-challenge` | A DNS-01 or HTTP-01 challenge used to prove domain ownership during issuance |
+| `certificate-secret` | The Kubernetes Secret storing the issued certificate, consumed by the Istio ingress gateway |

--- a/docs/platform-teams/pneuma/cluster-management.md
+++ b/docs/platform-teams/pneuma/cluster-management.md
@@ -20,7 +20,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 | Entity | Description |
 |---|---|
-| `gke-cluster` | A regional GKE cluster (regional control plane with zone-scoped node pools, e.g., `pt-pneuma-us-east1`) with KMS encryption, Workload Identity, and CIS hardening — regional control planes with zone-scoped node pools reduce Istio control plane hotspots |
+| `gke-cluster` | A regional GKE cluster (regional control plane with zone-scoped node pools, e.g., `pt-pneuma-us-east1-b`) with KMS encryption, Workload Identity, and CIS hardening — regional control planes with zone-scoped node pools reduce Istio control plane hotspots |
 | `node-pool` | A managed node pool with auto-provisioning, node auto-repair, and auto-upgrade |
 | `fleet` | A GKE Fleet registration enabling multi-cluster service discovery and ingress across zones |
 | `workload-identity` | Kubernetes-to-GCP service account mapping, allowing pods to authenticate to GCP without keys |

--- a/docs/platform-teams/pneuma/cluster-management.md
+++ b/docs/platform-teams/pneuma/cluster-management.md
@@ -16,6 +16,15 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `gke-cluster` | A zonal GKE cluster (e.g., `pt-pneuma-us-east1-b`) with KMS encryption, Workload Identity, and CIS hardening |
+| `node-pool` | A managed node pool with auto-provisioning, node auto-repair, and auto-upgrade |
+| `fleet` | A GKE Fleet registration enabling multi-cluster service discovery and ingress across zones |
+| `workload-identity` | Kubernetes-to-GCP service account mapping, allowing pods to authenticate to GCP without keys |
+
 ## Architecture Decision Records
 
 ### One Cluster Per Zone with Five Bounded Contexts

--- a/docs/platform-teams/pneuma/cluster-management.md
+++ b/docs/platform-teams/pneuma/cluster-management.md
@@ -20,7 +20,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 | Entity | Description |
 |---|---|
-| `gke-cluster` | A zonal GKE cluster (e.g., `pt-pneuma-us-east1-b`) with KMS encryption, Workload Identity, and CIS hardening |
+| `gke-cluster` | A regional GKE cluster (regional control plane with zone-scoped node pools, e.g., `pt-pneuma-us-east1`) with KMS encryption, Workload Identity, and CIS hardening — regional control planes with zone-scoped node pools reduce Istio control plane hotspots |
 | `node-pool` | A managed node pool with auto-provisioning, node auto-repair, and auto-upgrade |
 | `fleet` | A GKE Fleet registration enabling multi-cluster service discovery and ingress across zones |
 | `workload-identity` | Kubernetes-to-GCP service account mapping, allowing pods to authenticate to GCP without keys |

--- a/docs/platform-teams/pneuma/index.md
+++ b/docs/platform-teams/pneuma/index.md
@@ -15,6 +15,24 @@ Pneuma is the breath of life animating the platform via Kubernetes — orchestra
 
 Pneuma consumes Corpus networking and Logos team data to create fully operational Kubernetes environments.
 
+## Domain-Driven Design
+
+Pneuma is a downstream **Customer/Supplier** consumer of Corpus (networking and project infrastructure) and the Arche Shared Kernel (team data originating in Logos). It is an upstream supplier of Kubernetes clusters to all teams that need one — including Kryptos, which runs OpenBao on a Pneuma-managed cluster. See the [context map](/platform-teams#context-map).
+
+**Ubiquitous Language:** cluster, zone, node pool, fleet, workload identity, service mesh, certificate, constraint, policy, operator
+
+### Downstream Interfaces
+
+| Output | Consumed By | Via | Description |
+|---|---|---|---|
+| GKE cluster | All teams | Direct cluster provisioning | Kubernetes environment for workload deployment |
+| Kubernetes namespace | All teams | Logos team provisioning | Isolated namespace per team per cluster |
+| GKE cluster | Kryptos | Direct cluster provisioning | Dedicated cluster for OpenBao secrets infrastructure |
+
+### Core Invariant
+
+Every cluster has mTLS enforced, policy enforcement active, and observability running.
+
 ## Repositories
 
 - **[pt-pneuma](https://github.com/osinfra-io/pt-pneuma)**: OpenTofu configuration for GKE clusters and Kubernetes add-ons (cert-manager, Istio, OPA Gatekeeper, Datadog Operator)

--- a/docs/platform-teams/pneuma/observability.md
+++ b/docs/platform-teams/pneuma/observability.md
@@ -6,6 +6,16 @@ sidebar_label: Observability
 
 The Datadog Operator runs on every GKE cluster and manages the Datadog Agent DaemonSet via a `DatadogAgent` custom resource. The operator authenticates using per-team API and app keys provisioned by Logos and injected as GitHub Actions secrets.
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `datadog-operator` | The Kubernetes operator that manages the lifecycle of Datadog Agent deployments |
+| `datadog-agent` | A cluster-level CRD defining the desired state of the Datadog Agent (features, log collection, APM) |
+| `daemon-set` | The underlying Kubernetes DaemonSet that runs a Datadog Agent pod on every node |
+| `cluster-agent` | A single-instance Datadog Cluster Agent that aggregates cluster-level metrics and forwards them to Datadog |
+| `metrics-config` | Configuration enabling specific metric collection (container, Kubernetes state, network) |
+
 ## Always-on features
 
 These features are hardcoded enabled in the `DatadogAgent` spec:

--- a/docs/platform-teams/pneuma/policy-enforcement.md
+++ b/docs/platform-teams/pneuma/policy-enforcement.md
@@ -15,6 +15,15 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `constraint-template` | A reusable policy definition written in Rego — parameterizable and cluster-scoped |
+| `constraint` | An instance of a `constraint-template` with specific parameters (e.g., required label keys) |
+| `rego-policy` | The Rego logic embedded in a `constraint-template` that defines what is and is not admitted |
+| `audit-result` | A violation record produced when an existing resource fails a constraint in audit mode |
+
 ## Policies
 
 | Constraint | Enforcement | Description |

--- a/docs/platform-teams/pneuma/service-mesh.md
+++ b/docs/platform-teams/pneuma/service-mesh.md
@@ -10,3 +10,14 @@ Istio is deployed on every GKE cluster, providing mTLS between services, fine-gr
 - **Traffic management**: Istio VirtualServices and DestinationRules control routing, retries, and timeouts
 - **Ingress gateway**: External traffic enters the mesh through a managed gateway with Datadog AAP (Application and API Protection) deployed as an Envoy external processor for WAF and threat detection
 - **cert-manager integration**: Istio's built-in CA is replaced by cert-manager via istio-csr, which issues and rotates all workload mTLS certificates in the mesh
+
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `istio-control-plane` | The Istio control plane deployed via Helm, managing traffic policy across the mesh |
+| `ingress-gateway` | A managed ingress gateway exposed via a GCP load balancer |
+| `waf-policy` | A Cloud Armor security policy attached to the ingress gateway (OWASP rules, rate limiting, adaptive DDoS) |
+| `virtual-service` | An Istio routing rule defining traffic behaviour for a service (retries, timeouts, fault injection) |
+| `destination-rule` | An Istio policy defining connection pool and circuit breaker settings for a destination |
+| `peer-authentication` | A mesh-wide policy enforcing strict mTLS between all services |

--- a/docs/platform-teams/techne/deployment-automation.md
+++ b/docs/platform-teams/techne/deployment-automation.md
@@ -8,3 +8,16 @@ Reusable GitHub Actions called workflows that standardize OpenTofu deployments a
 
 - **[pt-techne-opentofu-workflows](https://github.com/osinfra-io/pt-techne-opentofu-workflows)**: Called workflows for OpenTofu deployments with OIDC auth, KMS-encrypted state, and structured job summaries — covers sandbox, sandbox destroy, non-production, production, module test, and child module test
 - **[pt-techne-misc-workflows](https://github.com/osinfra-io/pt-techne-misc-workflows)**: Reusable workflows for common repository tasks — Dependabot approve and merge, release automation, GitHub project tracking, container image build and push, and Nuclei vulnerability scanning
+
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `called-workflow` | A reusable GitHub Actions workflow invoked by every infrastructure repo's `sandbox.yml`, `non-production.yml`, and `production.yml` |
+| `oidc-token` | A short-lived GitHub Actions OIDC token exchanged for a GCP access token via Workload Identity Federation |
+| `plan-job` | A workflow job that runs `tofu plan` and uploads the plan artifact for review |
+| `apply-job` | A workflow job that downloads and applies a previously generated plan — never re-plans at apply time |
+| `state-backend-config` | The GCS bucket and KMS key configuration injected into each workflow job |
+| `job-summary` | A structured GitHub Actions job summary displaying plan output, drift, and resource counts |
+
+**Key rule:** All OpenTofu state lives in GitHub Actions. Local `tofu apply` against remote state is not permitted.

--- a/docs/platform-teams/techne/developer-experience.md
+++ b/docs/platform-teams/techne/developer-experience.md
@@ -16,6 +16,17 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+| Entity | Description |
+|---|---|
+| `codespace` | A GitHub Codespace pre-configured with OpenTofu, pre-commit, gcloud, kubectl, and all platform tooling |
+| `pre-commit-config` | A `.pre-commit-config.yaml` file pinned to specific hook versions — enforces `tofu fmt`, `tofu validate`, `tofu test`, YAML lint, and trailing whitespace |
+| `pre-commit-hook` | A custom hook (written in Go) implementing platform-specific IaC checks beyond what stock hooks provide |
+| `development-setup` | A local setup guide and script for engineers preferring native tooling over Codespaces |
+
+**Key rule:** `pre-commit run -a` must pass before any commit. The CI pipeline enforces the same checks — local and CI are identical environments.
+
 ## Architecture Decision Records
 
 ### GitHub Codespace as the Standard Development Environment

--- a/docs/platform-teams/techne/index.md
+++ b/docs/platform-teams/techne/index.md
@@ -7,7 +7,7 @@ description: The practiced art of making — the disciplined craft through which
 
 Techne is the practiced art of making — the disciplined craft through which raw materials of infrastructure are shaped into purposeful, refined platform instruments.
 
-Techne operates as an inner-source shared kernel: versioned GitHub Actions called workflows, pre-commit hooks, and developer tooling published on GitHub and consumed by every platform repo as pinned dependencies. See the [shared kernel ADR](#techne-as-an-inner-source-shared-kernel) for the rationale.
+Techne operates as the platform's conformist tooling layer: versioned GitHub Actions called workflows, pre-commit hooks, and developer tooling published on GitHub and consumed by every platform repo as pinned dependencies. See the [conformist tooling ADR](#techne-as-a-conformist-platform-tooling-layer) for the rationale.
 
 :::tip Architecture Decision Records
 
@@ -15,9 +15,38 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
+## Domain-Driven Design
+
+Techne operates using a **Conformist** pattern in the [context map](/platform-teams#context-map) — all platform teams adopt its workflows, hooks, and tooling as-is. There is no negotiation of interfaces.
+
+**Ubiquitous Language:** workflow, job, OIDC, pre-commit hook, codespace, toolchain
+
+### Bounded Contexts
+
+| Bounded Context | Artifacts | Consumed By |
+|---|---|---|
+| [Deployment Automation](./deployment-automation.md) | Called workflows, OIDC auth, state config, job summaries | All platform teams |
+| [Developer Experience](./developer-experience.md) | Codespace, pre-commit hooks, development setup | All platform teams |
+
+### Core Invariant
+
+All deployments use short-lived OIDC tokens — no static credentials exist anywhere on the platform.
+
+## Repositories
+
+- **[pt-techne-opentofu-workflows](https://github.com/osinfra-io/pt-techne-opentofu-workflows)**: Reusable GitHub Actions called workflows for OpenTofu deployments — see [Deployment Automation](./deployment-automation.md)
+- **[pt-techne-misc-workflows](https://github.com/osinfra-io/pt-techne-misc-workflows)**: Reusable GitHub Actions called workflows for common repository tasks
+- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Pre-commit hooks for IaC validation and formatting — see [Developer Experience](./developer-experience.md)
+- **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)**: GitHub Codespace configuration for standardized OpenTofu development environments
+- **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)**: Local development setup and tooling configuration
+
+### AI Context
+
+- **[pt-techne-ai-context](https://github.com/osinfra-io/pt-techne-ai-context)**: Team-level Copilot instructions for `pt-techne-*` repositories
+
 ## Architecture Decision Records
 
-### Techne as an Inner-Source Shared Kernel
+### Techne as a Conformist Platform Tooling Layer
 
 <table>
   <thead>
@@ -32,11 +61,11 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 Every platform repository needs the same foundational tooling: consistent OpenTofu deployment pipelines (OIDC auth, KMS-encrypted state, job summaries), pre-commit validation hooks, and a standardized developer environment. Without a shared approach, each repo would implement these independently, leading to drift and duplicated maintenance across dozens of repositories.
 
-This follows the same pattern as [Arche's shared kernel](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Ekklesia's shared kernel](/platform-teams/ekklesia#ekklesia-as-an-inner-source-shared-kernel) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
+This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type and DDD relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Decision
 
-Organize all shared platform tooling as an inner-source shared kernel under the `pt-techne-*` namespace. Each repository is:
+Organize all shared platform tooling as a conformist platform layer under the `pt-techne-*` namespace. Each repository is:
 
 - A standalone GitHub repository with its own versioning and release pipeline
 - Consumed by callers via pinned references (commit SHAs for actions, tagged versions for hooks)
@@ -54,12 +83,3 @@ The scope of consumers is broader than Arche — every platform repository uses 
 - Deployment pipeline improvements (new inputs, job summary changes) propagate to all consumers on their next workflow ref bump
 - Pre-commit hook fixes apply uniformly across all repos on the next `.pre-commit-config.yaml` update
 - The Techne team owns the upgrade path when called workflow interfaces change
-
-## Repositories
-
-- **[Deployment Automation](./deployment-automation.md)**: Reusable GitHub Actions workflows for OpenTofu deployments and common repository tasks
-- **[Developer Experience](./developer-experience.md)**: Codespace, pre-commit hooks, and local development setup
-
-### AI Context
-
-- **[pt-techne-ai-context](https://github.com/osinfra-io/pt-techne-ai-context)**: Team-level Copilot instructions for `pt-techne-*` repositories

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "webpack": "5.106.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",

--- a/sidebars.js
+++ b/sidebars.js
@@ -80,6 +80,15 @@ const sidebars = {
         'stream-aligned-teams/ethos/index',
       ],
     },
+    {
+      type: 'category',
+      label: 'Enabling Teams',
+      link: { type: 'doc', id: 'enabling-teams/index' },
+      items: [
+        'enabling-teams/soteria/index',
+        'enabling-teams/sophrosyne/index',
+      ],
+    },
   ],
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@algolia/abtesting@1.16.1":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@algolia/abtesting/-/abtesting-1.16.1.tgz#036ddd7ca49a4f5ba20ced09b9e0e5b913ccf6e8"
-  integrity sha512-Xxk4l00pYI+jE0PNw8y0MvsQWh5278WRtZQav8/BMMi3HKi2xmeuqe11WJ3y8/6nuBHdv39w76OpJb09TMfAVQ==
+"@algolia/abtesting@1.16.2":
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/@algolia/abtesting/-/abtesting-1.16.2.tgz#f0f0db8a070c4dc0a08c35e851f97651e29f160a"
+  integrity sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
 "@algolia/autocomplete-core@1.19.2":
   version "1.19.2"
@@ -52,126 +52,126 @@
   resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz#5d723d8bdb448efbb1b0e1c7ff94cc18e5b1dc0e"
   integrity sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==
 
-"@algolia/client-abtesting@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.50.1.tgz#b95230e48458dd89b6c3a65616f4d44fc87f2823"
-  integrity sha512-4peZlPXMwTOey9q1rQKMdCnwZb/E95/1e+7KujXpLLSh0FawJzg//U2NM+r4AiJy4+naT2MTBhj0K30yshnVTA==
+"@algolia/client-abtesting@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz#0fa6442c8792221d77bbfd42308d7f60aafe4edd"
+  integrity sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/client-analytics@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.50.1.tgz#7dac25fd8ed90385dbf2ddb88ac7bbafb3fe6e64"
-  integrity sha512-i+aWHHG8NZvGFHtPeMZkxL2Loc6Fm7iaRo15lYSMx8gFL+at9vgdWxhka7mD1fqxkrxXsQstUBCIsSY8FvkEOw==
+"@algolia/client-analytics@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.50.2.tgz#458d2c4119ff543dfd2c0ebd685ac6c3c279bdec"
+  integrity sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/client-common@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.50.1.tgz#c29b1b1f3e9098f36ee867413b2366893234b5bb"
-  integrity sha512-Hw52Fwapyk/7hMSV/fI4+s3H9MGZEUcRh4VphyXLAk2oLYdndVUkc6KBi0zwHSzwPAr+ZBwFPe2x6naUt9mZGw==
+"@algolia/client-common@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.50.2.tgz#059ff282b52106f592d77a59b3993d01e51d2918"
+  integrity sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==
 
-"@algolia/client-insights@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-insights/-/client-insights-5.50.1.tgz#a703061a62a860e48c46b62c499d6faac6667022"
-  integrity sha512-Bn/wtwhJ7p1OD/6pY+Zzn+zlu2N/SJnH46md/PAbvqIzmjVuwjNwD4y0vV5Ov8naeukXdd7UU9v550+v8+mtlg==
+"@algolia/client-insights@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-insights/-/client-insights-5.50.2.tgz#4606f3b9a7c3dee42ff8fbb665f189ad6f1630c8"
+  integrity sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/client-personalization@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.50.1.tgz#d03ef231498c9cb080193c2bd13178c959203400"
-  integrity sha512-0V4Tu0RWR8YxkgI9EPVOZHGE4K5pEIhkLNN0CTkP/rnPsqaaSQpNMYW3/mGWdiKOWbX0iVmwLB9QESk3H0jS5g==
+"@algolia/client-personalization@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.50.2.tgz#a3b536106afe5940fb0ad4c864ada2c8c8a11f04"
+  integrity sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/client-query-suggestions@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.1.tgz#5ee9038b930fd19f1caf1110789ab0fd55fb00b2"
-  integrity sha512-jofcWNYMXJDDr87Z2eivlWY6o71Zn7F7aOvQCXSDAo9QTlyf7BhXEsZymLUvF0O1yU9Q9wvrjAWn8uVHYnAvgw==
+"@algolia/client-query-suggestions@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz#44180b6a7381c2070fe7c006c673f0b5d4b56c4f"
+  integrity sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/client-search@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.50.1.tgz#c49cb76919adc953000de358aaf14722f2c35c32"
-  integrity sha512-OteRb8WubcmEvU0YlMJwCXs3Q6xrdkb0v50/qZBJP1TF0CvujFZQM++9BjEkTER/Jr9wbPHvjSFKnbMta0b4dQ==
+"@algolia/client-search@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.50.2.tgz#27501c5c0a457891c5246d6c23e3c4b81bba8e8e"
+  integrity sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
 "@algolia/events@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@algolia/events/-/events-4.0.1.tgz#fd39e7477e7bc703d7f893b556f676c032af3950"
   integrity sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==
 
-"@algolia/ingestion@1.50.1":
-  version "1.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/ingestion/-/ingestion-1.50.1.tgz#d6f267c7050db7857139d458ed78dda4cbc06090"
-  integrity sha512-0GmfSgDQK6oiIVXnJvGxtNFOfosBspRTR7csCOYCTL1P8QtxX2vDCIKwTM7xdSAEbJaZ43QlWg25q0Qdsndz8Q==
+"@algolia/ingestion@1.50.2":
+  version "1.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/ingestion/-/ingestion-1.50.2.tgz#ea485239264d5c8296387d3a4563fbe7b025cdf4"
+  integrity sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/monitoring@1.50.1":
-  version "1.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/monitoring/-/monitoring-1.50.1.tgz#90c58fbfaa87885200ad2e8421fee96a15574717"
-  integrity sha512-ySuigKEe4YjYV3si8NVk9BHQpFj/1B+ON7DhhvTvbrZJseHQQloxzq0yHwKmznSdlO6C956fx4pcfOKkZClsyg==
+"@algolia/monitoring@1.50.2":
+  version "1.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/monitoring/-/monitoring-1.50.2.tgz#2a346a7445bb965b2930bdb6303a7f9361da3320"
+  integrity sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/recommend@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.50.1.tgz#1b3298c203b4434698673471b490565550211442"
-  integrity sha512-Cp8T/B0gVmjFlzzp6eP47hwKh5FGyeqQp1N48/ANDdvdiQkPqLyFHQVDwLBH0LddfIPQE+yqmZIgmKc82haF4A==
+"@algolia/recommend@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.50.2.tgz#8f0264ffbbfe183198e3ee8dbe9d621bfa0d248c"
+  integrity sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==
   dependencies:
-    "@algolia/client-common" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
-"@algolia/requester-browser-xhr@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.1.tgz#207659a24e8f7b933016457e36f58d7637578c18"
-  integrity sha512-XKdGGLikfrlK66ZSXh/vWcXZZ8Vg3byDFbJD8pwEvN1FoBRGxhxya476IY2ohoTymLa4qB5LBRlIa+2TLHx3Uw==
+"@algolia/requester-browser-xhr@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz#8285f922d2ac4ff5663cb0b22f28e3f32727b9cf"
+  integrity sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==
   dependencies:
-    "@algolia/client-common" "5.50.1"
+    "@algolia/client-common" "5.50.2"
 
-"@algolia/requester-fetch@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-fetch/-/requester-fetch-5.50.1.tgz#44de75a3371207ff82875d359d67cce77f203d9b"
-  integrity sha512-mBAU6WyVsDwhHyGM+nodt1/oebHxgvuLlOAoMGbj/1i6LygDHZWDgL1t5JEs37x9Aywv7ZGhqbM1GsfZ54sU6g==
+"@algolia/requester-fetch@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz#a0c33f399be213d6f678d2b7ca91fc5e9435a619"
+  integrity sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==
   dependencies:
-    "@algolia/client-common" "5.50.1"
+    "@algolia/client-common" "5.50.2"
 
-"@algolia/requester-node-http@5.50.1":
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.50.1.tgz#f643e98b1e83e62bdd7cbc7324c6d3890d7508e5"
-  integrity sha512-qmo1LXrNKLHvJE6mdQbLnsZAoZvj7VyF2ft4xmbSGWI2WWm87fx/CjUX4kEExt4y0a6T6nEts6ofpUfH5TEE1A==
+"@algolia/requester-node-http@5.50.2":
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz#c5e3a3cf2863393c7d9f012a455973c48fd140a4"
+  integrity sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==
   dependencies:
-    "@algolia/client-common" "5.50.1"
+    "@algolia/client-common" "5.50.2"
 
 "@antfu/install-pkg@^1.1.0":
   version "1.1.0"
@@ -2050,17 +2050,17 @@
     tslib "^2.4.0"
 
 "@emnapi/core@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
-  integrity sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
   dependencies:
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
 "@emnapi/runtime@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
-  integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
   dependencies:
     tslib "^2.4.0"
 
@@ -3595,24 +3595,24 @@ algoliasearch-helper@^3.26.0:
     "@algolia/events" "^4.0.1"
 
 algoliasearch@^5.37.0:
-  version "5.50.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.50.1.tgz#f645227b146f089eb9728e73ee6e462e43b89de1"
-  integrity sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==
+  version "5.50.2"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.50.2.tgz#0ce5bc3ca15c7854e4845b9cbbe29fc2854d9627"
+  integrity sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==
   dependencies:
-    "@algolia/abtesting" "1.16.1"
-    "@algolia/client-abtesting" "5.50.1"
-    "@algolia/client-analytics" "5.50.1"
-    "@algolia/client-common" "5.50.1"
-    "@algolia/client-insights" "5.50.1"
-    "@algolia/client-personalization" "5.50.1"
-    "@algolia/client-query-suggestions" "5.50.1"
-    "@algolia/client-search" "5.50.1"
-    "@algolia/ingestion" "1.50.1"
-    "@algolia/monitoring" "1.50.1"
-    "@algolia/recommend" "5.50.1"
-    "@algolia/requester-browser-xhr" "5.50.1"
-    "@algolia/requester-fetch" "5.50.1"
-    "@algolia/requester-node-http" "5.50.1"
+    "@algolia/abtesting" "1.16.2"
+    "@algolia/client-abtesting" "5.50.2"
+    "@algolia/client-analytics" "5.50.2"
+    "@algolia/client-common" "5.50.2"
+    "@algolia/client-insights" "5.50.2"
+    "@algolia/client-personalization" "5.50.2"
+    "@algolia/client-query-suggestions" "5.50.2"
+    "@algolia/client-search" "5.50.2"
+    "@algolia/ingestion" "1.50.2"
+    "@algolia/monitoring" "1.50.2"
+    "@algolia/recommend" "5.50.2"
+    "@algolia/requester-browser-xhr" "5.50.2"
+    "@algolia/requester-fetch" "5.50.2"
+    "@algolia/requester-node-http" "5.50.2"
 
 ansi-align@^3.0.1:
   version "3.0.1"
@@ -3705,12 +3705,12 @@ astring@^1.8.0:
   integrity sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==
 
 autoprefixer@^10.4.19, autoprefixer@^10.4.23:
-  version "10.4.27"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.27.tgz#51ea301a5c3c5f8642f8e564759c4f573be486f2"
-  integrity sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.5.0.tgz#33d87e443430f020a0f85319d6ff1593cb291be9"
+  integrity sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==
   dependencies:
-    browserslist "^4.28.1"
-    caniuse-lite "^1.0.30001774"
+    browserslist "^4.28.2"
+    caniuse-lite "^1.0.30001787"
     fraction.js "^5.3.4"
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
@@ -3773,9 +3773,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.17"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz#435c101835c314c2d89d768795e1ea79941fafd3"
-  integrity sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==
+  version "2.10.19"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
+  integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
 
 batch@0.6.1:
   version "0.6.1"
@@ -3866,7 +3866,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.28.1:
+browserslist@^4.0.0, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -3981,10 +3981,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001774, caniuse-lite@^1.0.30001782:
-  version "1.0.30001787"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz#fd25c5e42e2d35df5c75eddda00d15d9c0c68f81"
-  integrity sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001782, caniuse-lite@^1.0.30001787:
+  version "1.0.30001788"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
+  integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -5132,9 +5132,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.335"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz#0b957cea44ef86795c227c616d16b4803d119daa"
-  integrity sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==
+  version "1.5.339"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz#d797bf5f222a7f6241a42b43a97bf52ff43947f1"
+  integrity sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -8547,9 +8547,9 @@ postcss-zindex@^6.0.2:
   integrity sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==
 
 postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.5.4:
-  version "8.5.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.9.tgz#f6ee9e0b94f0f19c97d2f172bfbd7fc71fe1cca4"
-  integrity sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
+  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
@@ -9061,10 +9061,11 @@ resolve-pathname@^3.0.0:
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve@^1.22.11:
-  version "1.22.11"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
-  integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
   dependencies:
+    es-errors "^1.3.0"
     is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
@@ -9804,9 +9805,9 @@ undici-types@~7.19.0:
   integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
 undici@^7.19.0:
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.7.tgz#af9535341bbe80625ca403a02418477a5c6a8760"
-  integrity sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
+  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"
@@ -10185,6 +10186,36 @@ webpack@5.105.4, webpack@^5.88.1, webpack@^5.95.0:
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.3.1"
     mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^4.3.3"
+    tapable "^2.3.0"
+    terser-webpack-plugin "^5.3.17"
+    watchpack "^2.5.1"
+    webpack-sources "^3.3.4"
+
+webpack@5.106.2:
+  version "5.106.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.106.2.tgz#ca8174b4fd80f055cc5a45fcc5577d6db76c8ac5"
+  integrity sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.7"
+    "@types/estree" "^1.0.8"
+    "@types/json-schema" "^7.0.15"
+    "@webassemblyjs/ast" "^1.14.1"
+    "@webassemblyjs/wasm-edit" "^1.14.1"
+    "@webassemblyjs/wasm-parser" "^1.14.1"
+    acorn "^8.16.0"
+    acorn-import-phases "^1.0.3"
+    browserslist "^4.28.1"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.20.0"
+    es-module-lexer "^2.0.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.11"
+    loader-runner "^4.3.1"
+    mime-db "^1.54.0"
     neo-async "^2.6.2"
     schema-utils "^4.3.3"
     tapable "^2.3.0"


### PR DESCRIPTION
Incorporates the full DDD model into the documentation site and adds the Enabling Teams section.

## Domain-Driven Design content

Added to all platform team index pages:

- **Ubiquitous Language** — the terms used when talking about each domain
- **Core Invariants** — the non-negotiable rules each domain enforces
- **Downstream Interfaces** — added to Logos, Corpus, and Pneuma (Pneuma was missing entirely)
- **Key rules** — added to Techne sub-pages (deployment-automation, developer-experience)
- **Bounded Contexts table** — added to Techne and Arche index pages
- **Modules heading** — added to Arche google-cloud and kubernetes sub-pages
- **Kebab-case entity names** — converted across all sub-pages (e.g. `GKECluster` → `gke-cluster`)

## Enabling Teams section

New top-level sidebar section with two placeholder pages:

- **Soteria** — security enabling team (safety, preservation — NT Greek)
- **Sophrosyne** — SRE enabling team (soundness, self-discipline — Platonic virtue, NT Greek)

## Fixes

- Deduplicated Repositories section in `ekklesia/index.md`
- Replaced display-name links with actual repo names in `techne/index.md`
- Added `pt-kryptos` and `pt-kryptos-ai-context` to `kryptos/index.md`
- Enforced ADR as last `##` heading on all pages
- Updated `copilot-instructions.md` with ADR placement rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Enabling Teams" section with Soteria (security practices) and Sophrosyne (reliability & observability) pages
  * Expanded platform-team docs with Domain-Driven Design content: domain boundaries, ubiquitous language, interfaces, and core invariants
  * Added many DDD subsections across team docs (Arche, Corpus, Logos, Pneuma, Techne, Kryptos, Ekklesia, etc.)
  * Updated site navigation to include the Enabling Teams category
  * Tightened ADR formatting and admonition placement guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->