### PR TITLE
Add Soteria to the docs site

### DIFF
--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -45,4 +45,5 @@ Logos runs OpenTofu on merge — the GCP folder hierarchy, identity groups, and 
 
 <CardGrid>
   <Card item={{ icon: '🧭', title: 'Ethos', note: 'The guiding philosophy that shapes platform principles.', link: '/stream-aligned-teams/ethos', linkText: 'Learn more →' }} />
+  <Card item={{ icon: '🛡️', title: 'Soteria', note: 'An enabling team that guides other teams in adopting security, safety, and resilience practices across the osinfra.io platform.', link: '/stream-aligned-teams/soteria', linkText: 'Learn more →' }} />
 </CardGrid>

--- a/docs/stream-aligned-teams/soteria/index.md
+++ b/docs/stream-aligned-teams/soteria/index.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Soteria
+description: An enabling team that guides other teams in adopting security, safety, and resilience practices across the osinfra.io platform.
+---
+
+# Soteria
+
+An enabling team that guides other teams in adopting security, safety, and resilience practices across the osinfra.io platform.


### PR DESCRIPTION
## Add Soteria to the docs site

Adds the `et-soteria` enabling team to the platform documentation.

### Changes

- `docs/stream-aligned-teams/index.md` — new `<Card>` for Soteria inserted alphabetically after Ethos
- `docs/stream-aligned-teams/soteria/index.md` — new team page

> Opened by the Logos Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Soteria team documentation page for security, safety, and resilience guidance.
  * Added Soteria card to Teams directory for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->