### PR TITLE
Add Foo to the docs site

### DIFF
--- a/docs/enabling-teams/foo/index.md
+++ b/docs/enabling-teams/foo/index.md
@@ -1,0 +1,8 @@
+---
+description: The Foo enabling team provides specialist expertise to help platform and stream-aligned teams adopt new capabilities and overcome obstacles.
+sidebar_label: Foo
+---
+
+# Foo
+
+The Foo enabling team provides specialist expertise to help platform and stream-aligned teams adopt new capabilities and overcome obstacles.

--- a/docs/enabling-teams/index.md
+++ b/docs/enabling-teams/index.md
@@ -13,6 +13,7 @@ Enabling teams provide specialist expertise on a temporary, collaborative basis 
 ## Teams
 
 <CardGrid>
+  <Card item={{ icon: '🧩', title: 'Foo', note: 'The Foo enabling team provides specialist expertise to help platform and stream-aligned teams adopt new capabilities and overcome obstacles.', link: '/enabling-teams/foo', linkText: 'Learn more →' }} />
   <Card item={{ icon: '🛡️', title: 'Soteria', note: 'The keeper of safety and preservation — embedding security practices, threat modeling, and compliance into the flow of every team rather than treating security as a gate.', link: '/enabling-teams/soteria', linkText: 'Learn more →' }} />
   <Card item={{ icon: '⚖️', title: 'Sophrosyne', note: 'The virtue of soundness and self-discipline — helping teams define reliability targets, build observability, and sustain the health of the platform through SLOs and incident response.', link: '/enabling-teams/sophrosyne', linkText: 'Learn more →' }} />
 </CardGrid>

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,6 +85,12 @@ const sidebars = {
       label: 'Enabling Teams',
       link: { type: 'doc', id: 'enabling-teams/index' },
       items: [
+        {
+          type: 'category',
+          label: 'Foo',
+          link: { type: 'doc', id: 'enabling-teams/foo/index' },
+          items: [],
+        },
         'enabling-teams/soteria/index',
         'enabling-teams/sophrosyne/index',
       ],


### PR DESCRIPTION
## Add Foo to the docs site

Adds the `et-foo` enabling team to the platform documentation.

### Changes
- `docs/enabling-teams/foo/index.md` — new team page
- `docs/enabling-teams/index.md` — adds Foo card to the enabling teams index
- `sidebars.js` — adds Foo to the Enabling Teams sidebar (alphabetical order)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new documentation page for the Foo enabling team
  * Added the Foo enabling team card to the teams overview page
  * Updated sidebar navigation to include the Foo enabling team

<!-- end of auto-generated comment: release notes by coderabbit.ai -->