### PR TITLE
Add Foo to the docs site

### DIFF
--- a/docs/enabling-teams/foo/index.md
+++ b/docs/enabling-teams/foo/index.md
@@ -1,0 +1,8 @@
+---
+description: The Foo enabling team provides temporary, focused guidance to help other teams quickly adopt new tools and practices.
+sidebar_label: Foo
+---
+
+# Foo
+
+The Foo enabling team provides temporary, focused guidance to help other teams quickly adopt new tools and practices.

--- a/docs/enabling-teams/index.md
+++ b/docs/enabling-teams/index.md
@@ -13,6 +13,7 @@ Enabling teams provide specialist expertise on a temporary, collaborative basis 
 ## Teams
 
 <CardGrid>
+  <Card item={{ icon: '🔧', title: 'Foo', note: 'The Foo enabling team provides temporary, focused guidance to help other teams quickly adopt new tools and practices.', link: '/enabling-teams/foo', linkText: 'Learn more →' }} />
   <Card item={{ icon: '🛡️', title: 'Soteria', note: 'The keeper of safety and preservation — embedding security practices, threat modeling, and compliance into the flow of every team rather than treating security as a gate.', link: '/enabling-teams/soteria', linkText: 'Learn more →' }} />
   <Card item={{ icon: '⚖️', title: 'Sophrosyne', note: 'The virtue of soundness and self-discipline — helping teams define reliability targets, build observability, and sustain the health of the platform through SLOs and incident response.', link: '/enabling-teams/sophrosyne', linkText: 'Learn more →' }} />
 </CardGrid>

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,6 +85,12 @@ const sidebars = {
       label: 'Enabling Teams',
       link: { type: 'doc', id: 'enabling-teams/index' },
       items: [
+        {
+          type: 'category',
+          label: 'Foo',
+          link: { type: 'doc', id: 'enabling-teams/foo/index' },
+          items: [],
+        },
         'enabling-teams/soteria/index',
         'enabling-teams/sophrosyne/index',
       ],


### PR DESCRIPTION
Adds the Foo enabling team to the docs site.

**Changes:**
- Creates `docs/enabling-teams/foo/index.md`
- Adds a `<Card>` for Foo to `docs/enabling-teams/index.md`
- Adds `et-foo` to the `'Enabling Teams'` section in `sidebars.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Foo enabling team documentation page with comprehensive overview and guidance information to support users seeking focused technical assistance
  * Added Foo enabling team card entry to the Teams index section for improved navigation and discoverability
  * Expanded sidebar navigation structure to include Foo enabling team documentation as a new organized category

<!-- end of auto-generated comment: release notes by coderabbit.ai -->