### PR TITLE
Update schema viewer and projects doc for platform-managed project

### DIFF
--- a/docs/platform-teams/corpus/data-services.md
+++ b/docs/platform-teams/corpus/data-services.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: Managed Data Services
+sidebar_label: Data Services
 ---
 
-# Managed Data Services
+# Data Services
 
 Corpus owns the VPC-level prerequisites that allow stream-aligned teams to consume Google managed data services — Cloud SQL and Memorystore (Redis) — from within the Shared VPC. It does not own the instances themselves; those belong to the teams that run them.
 

--- a/docs/platform-teams/corpus/data-services.md
+++ b/docs/platform-teams/corpus/data-services.md
@@ -15,15 +15,6 @@ Corpus owns the VPC-level prerequisites that allow stream-aligned teams to consu
 
 **Key rule:** Managed data service VPC prerequisites are provisioned once per environment by Corpus. Stream-aligned teams provision their own instances after this foundation exists.
 
-## Responsibilities by Team
-
-| Work | Owner | Scope |
-|---|---|---|
-| Private Services Access peering + reserved IP range in host VPC | **Corpus** | One-time per environment; covers both Cloud SQL and Memorystore |
-| `pt-arche-google-cloud-sql` module | **Arche** | Existing module |
-| `pt-arche-google-memorystore-redis` module | **Arche** | New module, same pattern as `pt-arche-google-cloud-sql` |
-| Instance declarations, Pub/Sub topics/subscriptions, IAM bindings | **Stream-aligned teams** | Self-service, consumed from Arche modules |
-
 ## Pub/Sub
 
 Pub/Sub requires no platform prerequisites beyond what already exists. Private Google Access is enabled on all Shared VPC subnets, meaning pods reach `pubsub.googleapis.com` without NAT or additional configuration. Stream-aligned teams declare their own topics and subscriptions in their own repositories.

--- a/docs/platform-teams/corpus/data-services.md
+++ b/docs/platform-teams/corpus/data-services.md
@@ -1,0 +1,63 @@
+---
+sidebar_label: Managed Data Services
+---
+
+# Managed Data Services
+
+Corpus owns the VPC-level prerequisites that allow stream-aligned teams to consume Google managed data services — Cloud SQL and Memorystore (Redis) — from within the Shared VPC. It does not own the instances themselves; those belong to the teams that run them.
+
+## Domain
+
+| Entity | Description |
+|---|---|
+| `managed-services-ip-range` | A reserved IP range in the host VPC allocated for Google managed services Private Services Access |
+| `service-networking-connection` | The VPC peering connection between the host VPC and Google's managed services network |
+
+**Key rule:** Managed data service VPC prerequisites are provisioned once per environment by Corpus. Stream-aligned teams provision their own instances after this foundation exists.
+
+## Responsibilities by Team
+
+| Work | Owner | Scope |
+|---|---|---|
+| Private Services Access peering + reserved IP range in host VPC | **Corpus** | One-time per environment; covers both Cloud SQL and Memorystore |
+| `pt-arche-google-cloud-sql` module | **Arche** | Existing module |
+| `pt-arche-google-memorystore-redis` module | **Arche** | New module, same pattern as `pt-arche-google-cloud-sql` |
+| Instance declarations, Pub/Sub topics/subscriptions, IAM bindings | **Stream-aligned teams** | Self-service, consumed from Arche modules |
+
+## Pub/Sub
+
+Pub/Sub requires no platform prerequisites beyond what already exists. Private Google Access is enabled on all Shared VPC subnets, meaning pods reach `pubsub.googleapis.com` without NAT or additional configuration. Stream-aligned teams declare their own topics and subscriptions in their own repositories.
+
+## Architecture Decision Records
+
+### Corpus Owns the Data Layer VPC Prerequisites
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>April 2026</td><td>Corpus</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+Cloud SQL Private IP and Memorystore require a **Private Services Access** peering connection in the Shared VPC host project — a reserved IP range allocated for Google managed services and a `google_service_networking_connection` resource. Service-project teams cannot modify the host VPC. This work must be done by the team that owns it: Corpus.
+
+No new platform team is justified at this scale. Each stream-aligned team owns their own data service instances. The managed services handle backups, failover, and patching. The complexity that would justify a dedicated data platform team does not yet exist.
+
+#### Decision
+
+Corpus adds a **Managed Data Services** bounded context alongside Networking and CI/CD Enablement. Corpus provisions the Private Services Access peering once per environment. Stream-aligned teams are then self-service for Cloud SQL and Memorystore using Arche modules, and for Pub/Sub directly with no module dependency.
+
+#### Alternatives Considered
+
+- **Create a dedicated data platform team** — Rejected. No shared data infrastructure exists today. Each team owns their own instances. A dedicated team creates coordination overhead without delivering value. The signal to revisit: when multiple teams are running instances and the platform team is regularly fielding sizing, upgrade, or incident questions.
+- **Have stream-aligned teams provision the peering themselves** — Rejected. The peering lives in the Shared VPC host project, which stream-aligned teams do not own and cannot modify.
+
+#### Consequences
+
+- Cloud SQL and Memorystore Private IP are available to any team on the Shared VPC after the one-time Corpus PR per environment
+- Corpus does not own or manage individual data service instances — teams retain full autonomy over their own instances
+- The team topology expands to a dedicated data platform team only when shared data infrastructure (pooled clusters, platform-level schemas) appears on the roadmap

--- a/docs/platform-teams/corpus/index.md
+++ b/docs/platform-teams/corpus/index.md
@@ -9,7 +9,7 @@ Corpus is the embodiment of that order — the structural form where networks, s
 
 - **[Projects](./projects.md)**: CIS-compliant GCP project creation with standard labels
 - **[Networking](./networking.md)**: Shared VPC, subnets, DNS zones, Cloud NAT
-- **[Managed Data Services](./data-services.md)**: Private Services Access peering for Cloud SQL and Memorystore; Corpus owns the VPC prerequisites, teams own their instances
+- **[Data Services](./data-services.md)**: Private Services Access peering for Cloud SQL and Memorystore; Corpus owns the VPC prerequisites, teams own their instances
 - **[CI/CD Enablement](./ci-cd-enablement.md)**: GitHub Actions workload identity, Artifact Registry, encrypted OpenTofu state buckets
 
 Corpus consumes Logos outputs and provides the foundation for Pneuma workload environments.

--- a/docs/platform-teams/corpus/index.md
+++ b/docs/platform-teams/corpus/index.md
@@ -9,6 +9,7 @@ Corpus is the embodiment of that order — the structural form where networks, s
 
 - **[Projects](./projects.md)**: CIS-compliant GCP project creation with standard labels
 - **[Networking](./networking.md)**: Shared VPC, subnets, DNS zones, Cloud NAT
+- **[Managed Data Services](./data-services.md)**: Private Services Access peering for Cloud SQL and Memorystore; Corpus owns the VPC prerequisites, teams own their instances
 - **[CI/CD Enablement](./ci-cd-enablement.md)**: GitHub Actions workload identity, Artifact Registry, encrypted OpenTofu state buckets
 
 Corpus consumes Logos outputs and provides the foundation for Pneuma workload environments.
@@ -25,7 +26,7 @@ Corpus consumes Logos outputs and provides the foundation for Pneuma workload en
 
 Corpus is a downstream **Customer/Supplier** consumer of Logos, and an upstream supplier to Pneuma in the platform's [context map](/platform-teams#context-map).
 
-**Ubiquitous Language:** project, CIS benchmark, subnet, shared VPC, firewall rule, DNS zone, workload identity, artifact registry, state bucket
+**Ubiquitous Language:** project, CIS benchmark, subnet, shared VPC, firewall rule, DNS zone, workload identity, artifact registry, state bucket, managed-services-ip-range, service-networking-connection
 
 ### Downstream Interfaces
 

--- a/docs/platform-teams/corpus/projects.md
+++ b/docs/platform-teams/corpus/projects.md
@@ -26,7 +26,24 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 | `labels` | Standard label set derived from `module.core_helpers.labels` — always includes `env`, `team`, `managed-by` |
 | `monitoring-channel` | Cloud Monitoring notification channels for budget and infrastructure change alerts |
 
-## Architecture Decision Records
+## Project Types
+
+Corpus creates up to two distinct GCP projects per team, driven entirely by team configuration in [pt-logos](https://github.com/osinfra-io/pt-logos):
+
+| Type | Logos field | Label | Purpose |
+|---|---|---|---|
+| **Team project** | `enable_google_project: true` | `project-type: team` | Ad-hoc team workloads, additional APIs, team-specific resources |
+| **Platform-managed project** | `platform_managed_project: { ... }` | `project-type: platform-managed` | GKE clusters, managed data services (Cloud SQL, Redis), Artifact Registry |
+
+The **platform-managed project** is the shared workload project for a team. Its presence is declared in pt-logos and the project is created by pt-corpus. Its contents — GKE clusters, data services — are provisioned by pt-pneuma and stream-aligned team repositories consuming Arche modules.
+
+A team declares a platform-managed project by adding a `platform_managed_project` block to their `.tfvars` entry. Within that block, `kubernetes_engine` is optional — a team may have:
+
+- **GKE only** — `platform_managed_project.kubernetes_engine` with `locations`; no data services
+- **Data services only** — `platform_managed_project` block present, `kubernetes_engine` omitted
+- **Both** — `platform_managed_project.kubernetes_engine` with `locations` and data service configuration in the project
+
+
 
 ### CIS GCP Foundation Benchmark Compliance by Default
 

--- a/docs/platform-teams/corpus/projects.md
+++ b/docs/platform-teams/corpus/projects.md
@@ -33,7 +33,7 @@ Corpus creates up to two distinct GCP projects per team, driven entirely by team
 | Type | Logos field | Label | Purpose |
 |---|---|---|---|
 | **Team project** | `enable_google_project: true` | `project-type: team` | Ad-hoc team workloads, additional APIs, team-specific resources |
-| **Platform-managed project** | `platform_managed_project: { ... }` | `project-type: platform-managed` | GKE clusters, managed data services (Cloud SQL, Redis), Artifact Registry |
+| **Platform-managed project** | `platform_managed_project: { ... }` | `project-type: platform-managed` | GKE clusters, managed data services (Cloud SQL, Redis, etc.) |
 
 The **platform-managed project** is the shared workload project for a team. Its presence is declared in pt-logos and the project is created by pt-corpus. Its contents — GKE clusters, data services — are provisioned by pt-pneuma and stream-aligned team repositories consuming Arche modules.
 

--- a/docs/platform-teams/corpus/projects.md
+++ b/docs/platform-teams/corpus/projects.md
@@ -16,16 +16,6 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 :::
 
-## Domain
-
-| Entity | Description |
-|---|---|
-| `gcp-project` | A GCP project created under the correct environment folder with billing and APIs enabled |
-| `cis-policy` | A set of CIS GCP Foundation Benchmark controls applied at project creation (audit logging, OS Login, no default VPC) |
-| `billing-budget` | Automatic spending alerts at 50%, 75%, and 100% of threshold on every project |
-| `labels` | Standard label set derived from `module.core_helpers.labels` — always includes `env`, `team`, `managed-by` |
-| `monitoring-channel` | Cloud Monitoring notification channels for budget and infrastructure change alerts |
-
 ## Project Types
 
 Corpus creates up to two distinct GCP projects per team, driven entirely by team configuration in [pt-logos](https://github.com/osinfra-io/pt-logos):
@@ -43,7 +33,17 @@ A team declares a platform-managed project by adding a `platform_managed_project
 - **Data services only** — `platform_managed_project` block present, `kubernetes_engine` omitted
 - **Both** — `platform_managed_project.kubernetes_engine` with `locations` and data service configuration in the project
 
+## Domain
 
+| Entity | Description |
+|---|---|
+| `gcp-project` | A GCP project created under the correct environment folder with billing and APIs enabled |
+| `cis-policy` | A set of CIS GCP Foundation Benchmark controls applied at project creation (audit logging, OS Login, no default VPC) |
+| `billing-budget` | Automatic spending alerts at 50%, 75%, and 100% of threshold on every project |
+| `labels` | Standard label set derived from `module.core_helpers.labels` — always includes `env`, `team`, `managed-by` |
+| `monitoring-channel` | Cloud Monitoring notification channels for budget and infrastructure change alerts |
+
+## Architecture Decision Records
 
 ### CIS GCP Foundation Benchmark Compliance by Default
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -26,6 +26,7 @@ const sidebars = {
           items: [
             'platform-teams/corpus/projects',
             'platform-teams/corpus/networking',
+            'platform-teams/corpus/data-services',
             'platform-teams/corpus/ci-cd-enablement',
           ],
         },

--- a/src/components/SchemaViewer/logosTeamSchema.js
+++ b/src/components/SchemaViewer/logosTeamSchema.js
@@ -288,7 +288,7 @@ const logosTeamSchema = {
       kubernetes_engine: {
         type: 'object',
         required: false,
-        description: 'GKE cluster configuration, DNS zones, and Artifact Registry. Omit this block if the team needs only managed data services with no GKE.',
+        description: 'GKE cluster configuration, DNS zones, and Artifact Registry. Omit this block if the team needs only managed data services (Cloud SQL, Redis, etc.) with no GKE.',
         properties: {
           dns_subdomain: {
             type: 'string',

--- a/src/components/SchemaViewer/logosTeamSchema.js
+++ b/src/components/SchemaViewer/logosTeamSchema.js
@@ -274,109 +274,116 @@ const logosTeamSchema = {
     },
   },
 
-  google_kubernetes_engine_clusters: {
+  platform_managed_project: {
     type: 'object',
     required: false,
     description:
-      'GKE cluster configuration, DNS zones, and Artifact Registry. Only specify if the team needs Kubernetes clusters.',
+      'Platform-managed project configuration. Presence of this block drives creation of a shared GCP project in pt-corpus that hosts GKE clusters, managed data services (Cloud SQL, Redis), and other platform workloads. Omit entirely if the team needs neither GKE nor managed data services.',
     properties: {
-      dns_subdomain: {
-        type: 'string',
-        required: false,
-        description:
-          'DNS subdomain for team services. Defaults to the team key with prefix removed. Creates zones: {subdomain}.osinfra.io, {subdomain}.nonprod.osinfra.io, {subdomain}.sb.osinfra.io.',
-      },
       enable_datadog: {
         type: 'boolean',
         required: false,
-        description: "Enables Datadog Google Cloud integration for the team's Kubernetes project.",
+        description: "Enables Datadog Google Cloud integration for the team's platform-managed project. Applies to all workloads in the project — GKE clusters, data services, and other resources.",
       },
-      artifact_registry_groups_memberships: {
+      kubernetes_engine: {
         type: 'object',
         required: false,
-        description: 'Container registry access control groups.',
+        description: 'GKE cluster configuration, DNS zones, and Artifact Registry. Omit this block if the team needs only managed data services with no GKE.',
         properties: {
-          readers: {
-            type: 'object',
-            required: false,
-            description: 'Can pull container images (roles/artifactregistry.reader).',
-            properties: {
-              owners: { type: 'string[]', required: false, description: 'Email addresses.' },
-              managers: { type: 'string[]', required: false, description: 'Email addresses.' },
-              members: { type: 'string[]', required: false, description: 'Email addresses.' },
-            },
-          },
-          writers: {
-            type: 'object',
-            required: false,
-            description: 'Can push container images (roles/artifactregistry.writer).',
-            properties: {
-              owners: { type: 'string[]', required: false, description: 'Email addresses.' },
-              managers: { type: 'string[]', required: false, description: 'Email addresses.' },
-              members: { type: 'string[]', required: false, description: 'Email addresses.' },
-            },
-          },
-        },
-      },
-      locations: {
-        type: 'map',
-        required: true,
-        description:
-          'GKE cluster locations keyed by GCP zone (e.g., "us-east1-b"). Only us-east1 and us-east4 zones are supported.',
-        properties: {
-          enable_gke_hub_host: {
-            type: 'boolean',
+          dns_subdomain: {
+            type: 'string',
             required: false,
             description:
-              'Set true for exactly one cluster to act as the fleet host for multi-cluster service discovery and cross-cluster ingress.',
+              'DNS subdomain for team services. Defaults to the team key with prefix removed. Creates zones: {subdomain}.osinfra.io, {subdomain}.nonprod.osinfra.io, {subdomain}.sb.osinfra.io.',
           },
-          node_pools: {
+          artifact_registry_groups_memberships: {
+            type: 'object',
+            required: false,
+            description: 'Container registry access control groups.',
+            properties: {
+              readers: {
+                type: 'object',
+                required: false,
+                description: 'Can pull container images (roles/artifactregistry.reader).',
+                properties: {
+                  owners: { type: 'string[]', required: false, description: 'Email addresses.' },
+                  managers: { type: 'string[]', required: false, description: 'Email addresses.' },
+                  members: { type: 'string[]', required: false, description: 'Email addresses.' },
+                },
+              },
+              writers: {
+                type: 'object',
+                required: false,
+                description: 'Can push container images (roles/artifactregistry.writer).',
+                properties: {
+                  owners: { type: 'string[]', required: false, description: 'Email addresses.' },
+                  managers: { type: 'string[]', required: false, description: 'Email addresses.' },
+                  members: { type: 'string[]', required: false, description: 'Email addresses.' },
+                },
+              },
+            },
+          },
+          locations: {
             type: 'map',
             required: true,
-            description: 'Node pool configurations. At least one pool named "default-pool" must be defined.',
-            properties: {
-              machine_type: {
-                type: 'string',
-                required: true,
-                description: 'GCE machine type (e.g., "e2-standard-2").',
-              },
-              min_node_count: {
-                type: 'number',
-                required: true,
-                description: 'Minimum nodes for autoscaling. Can be 0 for cost savings.',
-              },
-              max_node_count: {
-                type: 'number',
-                required: true,
-                description: 'Maximum nodes for autoscaling.',
-              },
-            },
-          },
-          subnet: {
-            type: 'object',
-            required: true,
             description:
-              "IP ranges for this cluster's VPC subnet. All ranges must be non-overlapping across all teams and environments.",
+              'GKE cluster locations keyed by GCP zone (e.g., "us-east1-b"). Only us-east1 and us-east4 zones are supported.',
             properties: {
-              ip_cidr_range: {
-                type: 'string',
-                required: true,
-                description: 'Primary IP range for cluster nodes. Must be /20 or larger.',
+              enable_gke_hub_host: {
+                type: 'boolean',
+                required: false,
+                description:
+                  'Set true for exactly one cluster to act as the fleet host for multi-cluster service discovery and cross-cluster ingress.',
               },
-              master_ipv4_cidr_block: {
-                type: 'string',
+              node_pools: {
+                type: 'map',
                 required: true,
-                description: 'Control plane IP range. Must be /28.',
+                description: 'Node pool configurations. At least one pool named "default-pool" must be defined.',
+                properties: {
+                  machine_type: {
+                    type: 'string',
+                    required: true,
+                    description: 'GCE machine type (e.g., "e2-standard-2").',
+                  },
+                  min_node_count: {
+                    type: 'number',
+                    required: true,
+                    description: 'Minimum nodes for autoscaling. Can be 0 for cost savings.',
+                  },
+                  max_node_count: {
+                    type: 'number',
+                    required: true,
+                    description: 'Maximum nodes for autoscaling.',
+                  },
+                },
               },
-              pod_ip_cidr_range: {
-                type: 'string',
+              subnet: {
+                type: 'object',
                 required: true,
-                description: 'Secondary IP range for pods. Must be /15 or larger.',
-              },
-              services_ip_cidr_range: {
-                type: 'string',
-                required: true,
-                description: 'Secondary IP range for Kubernetes Services.',
+                description:
+                  "IP ranges for this cluster's VPC subnet. All ranges must be non-overlapping across all teams and environments.",
+                properties: {
+                  ip_cidr_range: {
+                    type: 'string',
+                    required: true,
+                    description: 'Primary IP range for cluster nodes. Must be /20 or larger.',
+                  },
+                  master_ipv4_cidr_block: {
+                    type: 'string',
+                    required: true,
+                    description: 'Control plane IP range. Must be /28.',
+                  },
+                  pod_ip_cidr_range: {
+                    type: 'string',
+                    required: true,
+                    description: 'Secondary IP range for pods. Must be /15 or larger.',
+                  },
+                  services_ip_cidr_range: {
+                    type: 'string',
+                    required: true,
+                    description: 'Secondary IP range for Kubernetes Services.',
+                  },
+                },
               },
             },
           },

--- a/src/components/SchemaViewer/logosTeamSchema.js
+++ b/src/components/SchemaViewer/logosTeamSchema.js
@@ -278,12 +278,12 @@ const logosTeamSchema = {
     type: 'object',
     required: false,
     description:
-      'Platform-managed project configuration. Presence of this block drives creation of a shared GCP project in pt-corpus that hosts GKE clusters, managed data services (Cloud SQL, Redis), and other platform workloads. Omit entirely if the team needs neither GKE nor managed data services.',
+      'Platform-managed project configuration. Presence of this block drives creation of a shared GCP project in pt-corpus that hosts GKE clusters or managed data services (Cloud SQL, Redis, etc.). Omit entirely if the team needs neither.',
     properties: {
       enable_datadog: {
         type: 'boolean',
         required: false,
-        description: "Enables Datadog Google Cloud integration for the team's platform-managed project. Applies to all workloads in the project — GKE clusters, data services, and other resources.",
+        description: "Enables Datadog Google Cloud integration for the team's platform-managed project. Applies to all workloads in the project — GKE clusters and managed data services.",
       },
       kubernetes_engine: {
         type: 'object',


### PR DESCRIPTION
Updates the Docusaurus docs to reflect the `platform_managed_project` schema redesign landed in pt-logos PR #112.

## Changes

### `src/components/SchemaViewer/logosTeamSchema.js`

- Rename `google_kubernetes_engine_clusters` → `platform_managed_project`
- Restructure the block: `enable_datadog` moves to the top level of `platform_managed_project` (it applies to all workloads in the project, not just GKE)
- Add `kubernetes_engine` as an optional sub-object containing `dns_subdomain`, `artifact_registry_groups_memberships`, and `locations`
- Update descriptions to reflect that the project hosts GKE clusters, managed data services, and other platform workloads

### `docs/platform-teams/corpus/projects.md`

- Add **Project Types** section explaining the two project types corpus creates (`team` and `platform-managed`) and the Logos field that drives each
- Document the three usage patterns for a platform-managed project: GKE only, data services only, or both

## Related PRs

- pt-logos #112 — schema restructure (variables, outputs, tfvars)
- pt-corpus #88 — all renames + moved blocks
- pt-pneuma #87 — data source label filter updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced "Project Types" section documenting team and platform-managed project configuration options.
  * Added configuration mapping table and infrastructure provisioning guidance.

* **Refactor**
  * Reorganized Kubernetes and managed services configuration under unified platform-managed project settings.
  * Updated schema structure to clarify configuration requirements based on infrastructure needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->