### PR TITLE
Add Team Topologies domain documentation across all platform teams

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,24 @@ Every team (platform or stream-aligned) gets a folder, not a flat page. This all
 
 If a page has a `## Domain` section, it must always be the **second-to-last `##` heading on the page** — immediately before `## Architecture Decision Records` if ADRs exist, or the **last `##` heading** if there are no ADRs.
 
+Platform team pages follow this standard `###` subheading order within `## Domain`:
+
+1. **`### Ubiquitous Language`** — a `| Term | Meaning in this domain |` table sorted alphabetically. Establishes shared vocabulary before anything else.
+2. **`### Downstream Interfaces`** or **`### Bounded Contexts`** — a table mapping bounded contexts or artifacts to their consumers. Use `Downstream Interfaces` for teams with explicit customer/supplier relationships; use `Bounded Contexts` for shared kernel teams (Arche, Techne).
+3. **`### Core Invariant`** — a single sentence stating the one rule this domain must never violate. Omit only if there is no enforceable invariant (see Ekklesia).
+4. **`### Cognitive Load`** — Team Topologies cognitive load analysis: summary paragraph, working/high-intrinsic heat table, domain-by-domain table, capacity statement, extraneous load mitigations, germane load.
+5. **`### Team Capacity`** — a 3-row definition-style table (no header labels on columns):
+
+```md
+| | |
+|---|---|
+| **Headcount** | `1 domain engineer` / `1–2 domain engineers` / `Inner source — no dedicated engineer` |
+| **Day-to-day work** or **Contribution model** | What the work actually looks like day-to-day |
+| **Scale signal** | When (or whether) to add headcount |
+```
+
+Use `**Day-to-day work**` for staffed teams; use `**Contribution model**` for inner source teams.
+
 ## Architecture Decision Records
 
 ADRs live at the bottom of the relevant documentation page under a `## Architecture Decision Records` heading — not in separate files. This must always be the **last `##` heading on the page** — no sections follow it. Each ADR is a `###` subsection with a descriptive title.

--- a/docs/platform-teams/arche/index.md
+++ b/docs/platform-teams/arche/index.md
@@ -30,7 +30,18 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 Arche operates as the platform's **Shared Kernel** in the [context map](/platform-teams#context-map) — versioned OpenTofu modules consumed by all teams as pinned dependencies.
 
-**Ubiquitous Language:** module, source, ref, version, label, environment, workspace, helpers
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Environment | The deployment tier (sandbox, non-production, production) detected from the OpenTofu workspace name |
+| Helpers | The `pt-arche-core-helpers` module output struct providing env, labels, region, team, and teams data |
+| Label | A standard map of GCP resource tags applied to all resources (env, team, managed-by) |
+| Module | A versioned OpenTofu child module published in a `pt-arche-*` GitHub repository |
+| Ref | A 40-character commit SHA pinning a module to a specific post-merge state on `main` |
+| Source | The GitHub URL referencing a module, including the pinned commit SHA ref |
+| Version | A semver tag (e.g., v1.2.3) associated with a module release — documented as a comment alongside the ref |
+| Workspace | An OpenTofu workspace name encoding environment and optionally region or zone |
 
 ### Bounded Contexts
 
@@ -48,6 +59,44 @@ Arche is decomposed into two bounded contexts that map directly to the infrastru
 ### Core Invariant
 
 Every module `ref` must point to a post-merge commit SHA on `main` — never a branch name or semver tag. This makes every deployment reproducible and auditable.
+
+### Cognitive Load
+
+Arche's cognitive load centers on module design — building well-abstracted, versioned infrastructure primitives that reduce load for every team that consumes them. The Google Cloud context is medium complexity; the Kubernetes context is high, given the inherent complexity of the add-ons it packages.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟢 3 / 4 | 🟢 1 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Module Design & Versioning | 🟡 Medium | Template + Copilot agent | API design, semver strategy |
+| Google Cloud Patterns | 🟡 Medium | Pre-commit, mocked tests | GCP provider APIs |
+| Kubernetes Patterns | 🔴 High | Mocked provider tests | Helm, add-on internals |
+
+**Capacity**: 1 high-complexity domain (Team Topologies guideline: 2–3); team members hold 3 active domains — within the ~4 working-knowledge limit.
+
+**Extraneous load is minimized by:**
+
+- `pt-arche-child-module-template` and a Copilot agent scaffold new modules to the correct structure
+- Pre-commit hooks run `tofu fmt`, `tofu validate`, and `tofu test` automatically on every change
+- Mocked provider tests require no real GCP resources or credentials
+
+**Germane load is built through:**
+
+- IaC module design: API surface decisions, backward compatibility, and the cost of premature abstraction
+- Provider API mastery: understanding GCP and Kubernetes provider internals to build reliable, idiomatic modules
+- Versioning strategy: semver signalling, SHA pinning discipline, and coordinating the upgrade order across consumers
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | Inner source — no dedicated engineer |
+| **Contribution model** | Modules are built when a consuming team needs them and owned by whoever builds them; the child module template and Copilot agent make new module creation frictionless |
+| **Scale signal** | Scales with contributor interest — Arche is a domain standard and a set of versioned artifacts, not a team roster |
 
 ## Architecture Decision Records
 

--- a/docs/platform-teams/corpus/index.md
+++ b/docs/platform-teams/corpus/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Overview
+sidebar_label: Corpus
 description: The embodiment of that order — the structural form where networks, shared services, and core infrastructure take shape, preparing the body that Pneuma will animate.
 ---
 
@@ -26,7 +26,21 @@ Corpus consumes Logos outputs and provides the foundation for Pneuma workload en
 
 Corpus is a downstream **Customer/Supplier** consumer of Logos, and an upstream supplier to Pneuma in the platform's [context map](/platform-teams#context-map).
 
-**Ubiquitous Language:** project, CIS benchmark, subnet, shared VPC, firewall rule, DNS zone, workload identity, artifact registry, state bucket, managed-services-ip-range, service-networking-connection
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Artifact registry | A GCP container and artifact repository for storing built images |
+| CIS benchmark | The Center for Internet Security hardening standard applied to every project at creation |
+| DNS zone | A Cloud DNS zone for internal or external name resolution |
+| Firewall rule | A network policy controlling traffic between subnets and resources |
+| Managed services IP range | A private IP range reserved for Cloud SQL and Memorystore peering |
+| Project | A GCP project scoped to a team and environment, CIS-compliant at creation |
+| Service networking connection | A VPC peering link enabling Private Services Access for managed databases |
+| Shared VPC | A centrally-managed GCP network whose subnets are shared across team projects |
+| State bucket | A GCS bucket holding encrypted OpenTofu state for a team's infrastructure |
+| Subnet | An IP range within a shared VPC allocated to a team's cluster nodes and pods |
+| Workload identity | A GCP mechanism mapping a Kubernetes service account to a GCP service account — no static credentials |
 
 ### Downstream Interfaces
 
@@ -39,3 +53,42 @@ Corpus is a downstream **Customer/Supplier** consumer of Logos, and an upstream 
 ### Core Invariant
 
 Every GCP project is CIS-compliant at creation — there is no non-compliant state.
+
+### Cognitive Load
+
+Corpus translates Logos abstractions into concrete GCP infrastructure — projects, networks, and CI/CD foundations. Networking is the domain of highest inherent complexity here, spanning VPC design, multi-region subnets, DNS, NAT, and Private Services Access.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟠 4 / 4 | 🟢 1 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Projects | 🟡 Medium | Arche module | CIS compliance patterns |
+| Networking | 🔴 High | Arche module | VPC design, IP planning |
+| Data Services | 🟡 Medium | Corpus owns prerequisites | Managed services connectivity |
+| CI/CD Enablement | 🟡 Medium | Techne workflows | Workload identity, OIDC |
+
+**Capacity**: 1 high-complexity domain (Team Topologies guideline: 2–3); team members hold 4 active domains — at the ~4 working-knowledge limit.
+
+**Extraneous load is minimized by:**
+
+- Arche modules encapsulate CIS-compliant GCP project and network resource creation
+- Logos outputs drive project placement and team data — no manual cross-referencing
+- Techne's called workflows manage all CI/CD pipeline complexity
+
+**Germane load is built through:**
+
+- GCP networking architecture: VPC design, peering, and IP range planning
+- Cloud security posture: CIS benchmark controls, workload identity federation, and state encryption
+- Infrastructure supply chain thinking: how Corpus outputs shape what Pneuma can do
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | 1 domain engineer |
+| **Day-to-day work** | Provisioning new team projects, occasional subnet expansion, supporting Pneuma's cluster networking requirements |
+| **Scale signal** | Stable — networking and project infrastructure changes infrequently once designed |

--- a/docs/platform-teams/ekklesia/index.md
+++ b/docs/platform-teams/ekklesia/index.md
@@ -7,7 +7,7 @@ description: The assembly of the called-out — where distinct capabilities are 
 
 Ekklesia is the assembly of the called-out — where distinct capabilities are gathered into a unified body, deliberating and acting in concert toward shared platform purpose. This is that assembly.
 
-Ekklesia operates as the platform's shared knowledge domain: a single centralized documentation site where every platform team contributes, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [knowledge domain ADR](#ekklesia-as-the-platforms-shared-knowledge-domain) for the rationale.
+Ekklesia operates as the platform's shared knowledge domain: a single centralized documentation site where any team member can contribute, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [knowledge domain ADR](#ekklesia-as-the-platforms-shared-knowledge-domain) for the rationale.
 
 :::tip Architecture Decision Records
 
@@ -25,13 +25,59 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 ## Domain
 
-Ekklesia operates as the platform's **Shared Knowledge Domain** in the [context map](/platform-teams#context-map) — all teams contribute documentation here and consume it as the canonical reference for platform knowledge.
+Ekklesia operates as the platform's **Shared Knowledge Domain** in the [context map](/platform-teams#context-map) — all teams contribute documentation here and consume it as the canonical reference for platform knowledge. Because documentation lives in version control and goes through the same PR process as code, it is subject to the same quality standards. Every team owns their section; Ekklesia owns the structure and tooling that makes contribution frictionless.
 
-**Ubiquitous Language:** page, architecture decision record, sidebar, contributor
+### Ubiquitous Language
 
-### Core Invariant
+| Term | Meaning in this domain |
+|---|---|
+| Architecture decision record | A structured record of a significant design decision — context, decision, alternatives considered, and consequences |
+| Contributor | Any team member who opens a PR to add or update documentation |
+| Page | A Markdown file in `pt-ekklesia-docs` that renders as a documentation page in the Docusaurus site |
+| Sidebar | The Docusaurus navigation tree defined in `sidebars.js` that organizes pages into sections |
 
-When platform behaviour changes, the relevant doc page is updated in the same PR.
+### Downstream Interfaces
+
+| Output | Consumed By | Via | Description |
+|---|---|---|---|
+| Documentation site | All teams and stakeholders | [docs.osinfra.io](https://docs.osinfra.io) | Canonical reference for platform architecture, module usage, deployment patterns, and operational guides |
+| Architecture decision records | All teams | [docs.osinfra.io](https://docs.osinfra.io) | Structured records of design decisions that inform how teams build and operate on the platform |
+
+### Cognitive Load
+
+Ekklesia carries the lightest operational load of any platform team — its domain is documentation tooling, which is low inherent complexity. The real challenge is breadth of knowledge: contributing meaningfully to platform docs requires understanding every other team's domain.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟢 1 / 4 | 🟢 0 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Documentation | 🟢 Low | Docusaurus + GitHub Pages | Technical writing, platform-wide context |
+
+**Capacity**: 0 high-complexity domains (Team Topologies guideline: 2–3); team members hold 1 active domain — well within the ~4 working-knowledge limit.
+
+**Extraneous load is minimized by:**
+
+- Docusaurus and GitHub Pages handle all build and hosting automatically
+- All teams contribute via standard GitHub Flow — no separate wiki system or access model
+- Documentation lives in version control alongside the code it describes
+
+**Germane load is built through:**
+
+- Technical writing: structuring complex infrastructure concepts for different audiences
+- Information architecture: organizing platform knowledge so engineers can find what they need quickly
+- Platform-wide context: Ekklesia contributors develop a uniquely broad understanding of how all domains fit together
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | Inner source — no dedicated engineer |
+| **Contribution model** | Every team updates their section as part of their own PRs; Ekklesia owns the site structure and tooling, not the content |
+| **Scale signal** | No scaling expected — documentation is a distributed responsibility by design |
 
 ## Architecture Decision Records
 
@@ -58,7 +104,7 @@ Operate a single Docusaurus site (`pt-ekklesia-docs`) as the canonical platform 
 
 - Version-controlled alongside the code it documents
 - Automatically built on pull requests and deployed to [docs.osinfra.io](https://docs.osinfra.io) on merge to `main`
-- Open for contribution from any platform team via GitHub Flow
+- Open for contribution from any team member via GitHub Flow
 
 #### Alternatives Considered
 

--- a/docs/platform-teams/index.md
+++ b/docs/platform-teams/index.md
@@ -72,7 +72,7 @@ _🟢 within limit · 🟡 approaching · 🟠 at limit · 🔴 over limit_
 
 ### Team Capacity
 
-Headcount is derived from the cognitive load analysis above. Teams operating within capacity require one domain engineer to maintain and evolve their domain. Teams approaching or at their limit are candidates for additional capacity or domain reduction. Teams flagged 🔴 over limit are the highest priority for intervention — either a second engineer, scope reduction, or tooling investment to lower extraneous load.
+Headcount is derived from the cognitive load analysis above. When operating within capacity, a team requires one domain engineer to maintain and evolve its domain. A team approaching or at its limit is a candidate for additional capacity or scope reduction. Any team flagged 🔴 over limit is the highest priority for intervention — either a second engineer, scope reduction, or tooling investment to lower extraneous load.
 
 #### Platform Lead
 

--- a/docs/platform-teams/index.md
+++ b/docs/platform-teams/index.md
@@ -33,21 +33,86 @@ The primary flow is a **Customer/Supplier** chain — Logos supplies team and id
 ```mermaid
 flowchart TD
     Arche["🧱 Arche (Shared Kernel)"]
-    Techne["🛠️ Techne (Conformist)"]
+    Techne["🛠️ Techne (Shared Kernel)"]
     Ekklesia["📖 Ekklesia (Knowledge)"]
     Kryptos["🔐 Kryptos"]
     AllTeams(["All Teams"])
 
     subgraph sc ["Infrastructure Supply Chain"]
+        direction LR
         Logos["🏛️ Logos"] -->|"Customer/Supplier"| Corpus["🌐 Corpus"]
         Corpus -->|"Customer/Supplier"| Pneuma["☸️ Pneuma"]
     end
 
     Arche ==>|"Shared Kernel"| sc
-    Techne -.->|"Conformist"| sc
     Ekklesia -.->|"Knowledge"| sc
+    Techne ==>|"Shared Kernel"| sc
+    Techne ==>|"Shared Kernel"| AllTeams
 
     Pneuma -->|"Customer/Supplier"| Kryptos
     Pneuma -->|"Customer/Supplier"| AllTeams
     Kryptos -->|"Customer/Supplier"| AllTeams
 ```
+
+### Cognitive Load
+
+Team Topologies distinguishes three types of cognitive load — **intrinsic** (inherent domain complexity), **extraneous** (friction from poor tooling), and **germane** (productive expertise-building). The platform is designed to eliminate extraneous load through shared automation (Arche, Techne), so each team's cognitive budget is spent entirely on intrinsic and germane load.
+
+| Team | Working Domains | High Intrinsic Domains |
+|---|---|---|
+| Ekklesia | 🟢 1 / 4 | 🟢 0 / 3 |
+| Techne | 🟢 2 / 4 | 🟢 0 / 3 |
+| Arche | 🟢 3 / 4 | 🟢 1 / 3 |
+| Kryptos | 🟢 2 / 4 | 🟡 2 / 3 |
+| Logos | 🟠 4 / 4 | 🟢 0 / 3 |
+| Corpus | 🟠 4 / 4 | 🟢 1 / 3 |
+| Pneuma | 🔴 5 / 4 | 🟠 3 / 3 |
+
+_🟢 within limit · 🟡 approaching · 🟠 at limit · 🔴 over limit_
+
+### Team Capacity
+
+Headcount is derived from the cognitive load analysis above. Teams operating within capacity require one domain engineer to maintain and evolve their domain. Teams approaching or at their limit are candidates for additional capacity or domain reduction. Teams flagged 🔴 over limit are the highest priority for intervention — either a second engineer, scope reduction, or tooling investment to lower extraneous load.
+
+#### Platform Lead
+
+A single **Platform Lead** spans all seven teams. This role does not belong to any one team — it exists above them.
+
+Responsibilities:
+
+- Sets the platform's technical direction and architectural standards
+- Owns cross-team dependency sequencing (Logos → Corpus → Pneuma)
+- Reviews and ratifies Architecture Decision Records (ADRs) across all teams
+- Interfaces with stream-aligned team leads and engineering leadership
+- Unblocks cross-team decisions that no single domain engineer can resolve
+- Allocates capacity across staffed teams based on platform demand
+
+#### Domain Engineers
+
+Each staffed team has one domain engineer who owns that domain end-to-end. Pneuma is the exception — its operational surface scales with the number of clusters and stream-aligned teams consuming it.
+
+| Team | Engineers | Role |
+|---|---|---|
+| Logos | 1 | Owns org structure, identity, GitHub, and Datadog team management |
+| Corpus | 1 | Owns GCP projects, shared VPC, state buckets, and workload identity |
+| Pneuma | 1–2 | Owns GKE clusters, service mesh, policy enforcement, and cluster add-ons |
+| Kryptos | 1 | Owns secrets infrastructure, PKI, and cryptographic controls |
+| Arche | — | Inner source — no dedicated engineer |
+| Ekklesia | — | Inner source — no dedicated engineer |
+| Techne | — | Inner source — no dedicated engineer |
+
+**Total: 5–6 engineers + 1 Platform Lead**
+
+#### Inner Source Model
+
+Arche, Ekklesia, and Techne operate without dedicated engineers. Instead, they run as **inner source** repositories — open for contribution from any engineer on the platform or from stream-aligned teams.
+
+How it works:
+
+- Any engineer may open a pull request to an inner source repo
+- Domain engineers from staffed teams (Logos, Corpus, Pneuma, Kryptos) serve as code owners and reviewers
+- The Platform Lead has final approval authority on structural or architectural changes
+- Stream-aligned teams can unblock themselves by contributing fixes or enhancements directly, rather than filing tickets and waiting
+
+This model distributes platform knowledge across the organization, reduces bottlenecks on the staffed teams, and ensures inner source repos evolve with the needs of their consumers rather than on a centralized backlog.
+

--- a/docs/platform-teams/kryptos/index.md
+++ b/docs/platform-teams/kryptos/index.md
@@ -7,6 +7,8 @@ description: The hidden foundation of platform security — managing cryptograph
 
 The hidden foundation of platform security — managing cryptographic primitives, secrets infrastructure, and security controls that underpin all teams on the platform.
 
+- **[OpenBao](./open-bao.md)**: Dynamic secrets, PKI certificate issuance, and short-lived credentials for all teams — deployed on a dedicated Pneuma-managed cluster
+
 ## Repositories
 
 - **[pt-kryptos](https://github.com/osinfra-io/pt-kryptos)**: Secrets infrastructure and cryptographic primitives — OpenBao deployment and platform security controls
@@ -18,3 +20,66 @@ The hidden foundation of platform security — managing cryptographic primitives
 ## Domain
 
 Kryptos is a downstream **Customer/Supplier** consumer of Pneuma (runs OpenBao on Pneuma-managed clusters) and an upstream supplier of secrets management to all teams in the [context map](/platform-teams#context-map).
+
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Dynamic credential | A short-lived secret generated on demand and automatically revoked on lease expiry |
+| Engine | A secrets backend (PKI, KV, database) that generates or stores credentials |
+| Key | A cryptographic key managed by GCP KMS for encryption or signing |
+| Lease | A time-bound grant on a dynamic secret — expiry automatically revokes access |
+| Path | The OpenBao mount path addressing a specific secret or engine endpoint |
+| Policy | An OpenBao ACL rule controlling which paths a token can read or write |
+| Rotation | Replacing a secret or key before its lease or validity period expires |
+| Secret | A sensitive value (password, certificate, API key) managed by OpenBao |
+| Token | An OpenBao authentication credential scoped to one or more policies |
+
+### Downstream Interfaces
+
+| Artifact | Description | Consumed By |
+|---|---|---|
+| Dynamic credentials | Short-lived database, cloud, and API secrets issued on demand via OpenBao | All teams |
+| PKI certificates | Workload and service identity certificates issued from Kryptos-managed CA | All teams |
+| KV secrets | Static secrets (API keys, tokens) stored and versioned in OpenBao KV | All teams |
+
+### Core Invariant
+
+All secrets distributed to consumers are dynamic or short-lived — no static credentials are stored in consumer repositories or CI environments.
+
+### Cognitive Load
+
+Kryptos owns two domains of high inherent complexity — secrets infrastructure and cryptographic primitives. The scope is deliberately narrow: depth over breadth, with no cluster operations burden (Pneuma handles that) and no deployment pipeline overhead (Techne handles that).
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟢 2 / 4 | 🟡 2 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Secrets Infrastructure | 🔴 High | Pneuma-managed cluster | OpenBao, dynamic secrets |
+| Cryptographic Primitives | 🔴 High | GCP KMS handles key infrastructure | PKI, key lifecycle design |
+
+**Capacity**: 2 high-complexity domains (Team Topologies guideline: 2–3); team members hold 2 active domains — well within the ~4 working-knowledge limit. This leaves intentional headroom — scope expansion into a third high-complexity domain would approach the team's cognitive ceiling.
+
+**Extraneous load is minimized by:**
+
+- OpenBao runs on Pneuma-managed clusters — no cluster operations burden
+- GCP KMS manages key infrastructure at scale — Kryptos configures policy, not key primitives
+- Techne's called workflows handle all CI/CD pipelines
+
+**Germane load is built through:**
+
+- Security engineering: OpenBao policy authoring, dynamic secrets, and secrets lifecycle management
+- Applied cryptography: PKI chains, key rotation, and zero-trust secrets distribution
+- Zero-trust architecture: designing secrets access patterns that minimize blast radius
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | 1 domain engineer |
+| **Day-to-day work** | OpenBao policy authoring, PKI configuration, cryptographic key lifecycle management |
+| **Scale signal** | Intentionally narrow — scope should not grow to fill capacity; a third high-complexity domain would approach the cognitive ceiling |

--- a/docs/platform-teams/kryptos/open-bao.md
+++ b/docs/platform-teams/kryptos/open-bao.md
@@ -1,0 +1,25 @@
+---
+sidebar_label: OpenBao
+---
+
+# OpenBao
+
+OpenBao is an open-source secrets management platform — a Linux Foundation fork of HashiCorp Vault — deployed on a dedicated Pneuma-managed GKE cluster. It is the platform's canonical source of dynamic credentials, PKI certificates, and short-lived secrets for all teams.
+
+- **[Kubernetes auth](https://openbao.org/docs/auth/kubernetes/)**: Maps Kubernetes service accounts to OpenBao roles using the cluster's token review API — no static credentials required
+- **[PKI engine](https://openbao.org/docs/secrets/pki/)**: Issues and renews X.509 certificates on demand; integrates with cert-manager for automated workload certificate lifecycle
+- **[KV engine](https://openbao.org/docs/secrets/kv/)**: Versioned key-value store for static secrets that cannot be dynamically generated
+- **[Database engine](https://openbao.org/docs/secrets/databases/)**: Generates short-lived database credentials on demand and revokes them automatically on lease expiry
+
+All secrets issued by OpenBao are dynamic or time-bounded — no consumer stores long-lived credentials.
+
+## Domain
+
+| Entity | Description |
+|---|---|
+| `auth-method` | A Kubernetes or OIDC backend that authenticates callers and maps them to OpenBao roles |
+| `lease` | A time-bound grant on a dynamic secret — expiry automatically revokes access |
+| `policy` | An ACL rule controlling which paths a token can read, write, or delete |
+| `role` | A named binding that maps an auth identity to a set of policies and token TTLs |
+| `secrets-engine` | A PKI, KV, or database backend mounted at a path that generates or stores credentials |
+| `token` | An OpenBao authentication credential scoped to one or more policies |

--- a/docs/platform-teams/logos/index.md
+++ b/docs/platform-teams/logos/index.md
@@ -27,7 +27,18 @@ Corpus depends directly on Logos outputs. All other infrastructure domains consu
 
 Logos is the upstream **Customer/Supplier** to Corpus in the platform's [context map](/platform-teams#context-map).
 
-**Ubiquitous Language:** organization, environment, folder, identity group, team, repository, membership, branch protection
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Branch protection | A GitHub policy enforcing review and status check requirements on a repository |
+| Environment | A deployment tier (sandbox, non-production, production) represented as a GCP folder |
+| Folder | A GCP resource container that scopes IAM and billing within an environment |
+| Identity group | A Google Workspace group that grants role-based access to GCP resources |
+| Membership | The assignment of a user to an identity group or GitHub team |
+| Organization | The top-level GCP and GitHub entity that owns all platform resources |
+| Repository | A GitHub repository registered to a team and managed as code in Logos |
+| Team | A bounded ownership unit — one GitHub team, one GCP folder, one Datadog team, provisioned together from a single definition |
 
 ### Downstream Interfaces
 
@@ -39,3 +50,42 @@ Logos is the upstream **Customer/Supplier** to Corpus in the platform's [context
 ### Core Invariant
 
 Every team definition produces exactly one set of GCP, GitHub, and Datadog resources.
+
+### Cognitive Load
+
+Logos spans four domains across three SaaS providers — all driven from a single OpenTofu configuration. The cross-provider synchronization (GitHub + GCP + Datadog from one tfvars change) is the primary source of inherent complexity.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟠 4 / 4 | 🟢 0 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Resource Hierarchy | 🟡 Medium | IaC, no manual ops | GCP org & folder design |
+| Identity & Access | 🟡 Medium | IaC, no manual ops | Identity federation |
+| Team Topology | 🟡 Medium | One tfvars → three providers | Cross-provider team modeling |
+| SaaS Governance | 🟢 Low | Stable config, rarely changes | Org compliance policy |
+
+**Capacity**: 0 high-complexity domains (Team Topologies guideline: 2–3); team members hold 4 active domains — at the ~4 working-knowledge limit.
+
+**Extraneous load is minimized by:**
+
+- Everything is code — no manual GCP console, GitHub UI, or Datadog UI operations
+- A single tfvars edit propagates to all three providers in one deployment
+- Pre-commit hooks enforce format and validate before any change reaches CI
+
+**Germane load is built through:**
+
+- Multi-provider governance patterns and how org-wide policy propagates downstream
+- Domain-Driven Design: modeling teams as bounded contexts with explicit ownership boundaries
+- Reasoning about how changes in Logos ripple through Corpus and Pneuma
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | 1 domain engineer |
+| **Day-to-day work** | New team onboarding, user membership changes, governance policy updates across GitHub, GCP, and Datadog |
+| **Scale signal** | Stable — organizational structure is established; workload is routine maintenance |

--- a/docs/platform-teams/pneuma/index.md
+++ b/docs/platform-teams/pneuma/index.md
@@ -28,7 +28,20 @@ Pneuma consumes Corpus networking and Logos team data to create fully operationa
 
 Pneuma is a downstream **Customer/Supplier** consumer of Corpus (networking and project infrastructure) and the Arche Shared Kernel (team data originating in Logos). It is an upstream supplier of Kubernetes clusters to all teams that need one — including Kryptos, which runs OpenBao on a Pneuma-managed cluster. See the [context map](/platform-teams#context-map).
 
-**Ubiquitous Language:** cluster, zone, node pool, fleet, workload identity, service mesh, certificate, constraint, policy, operator
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Certificate | An mTLS leaf certificate issued by cert-manager and signed by the mesh CA |
+| Cluster | A GKE Kubernetes cluster deployed to one or more zones within a Corpus project |
+| Constraint | An OPA Gatekeeper policy rule enforced at admission time against incoming Kubernetes resources |
+| Fleet | A GCP construct grouping GKE clusters for unified management and policy |
+| Node pool | A group of identically configured VMs within a cluster that run workload pods |
+| Operator | A Kubernetes controller deployed as an add-on (Datadog Operator, cert-manager) managing its resource lifecycle |
+| Policy | A set of constraints defining the compliance posture for a cluster |
+| Service mesh | The Istio control plane managing mTLS, traffic routing, and observability across all pods |
+| Workload identity | A binding between a Kubernetes service account and a GCP service account — no static keys |
+| Zone | A GCP availability zone where cluster nodes run |
 
 ### Downstream Interfaces
 
@@ -41,3 +54,44 @@ Pneuma is a downstream **Customer/Supplier** consumer of Corpus (networking and 
 ### Core Invariant
 
 Every cluster has mTLS enforced, policy enforcement active, and observability running.
+
+### Cognitive Load
+
+Pneuma is the most cognitively demanding platform team. It operates three domains of high inherent complexity simultaneously — Kubernetes clusters, an Istio service mesh, and a full PKI chain for workload certificates — alongside policy enforcement and observability. This is by design: these domains are inseparable at the cluster layer, and Arche modules carry the implementation weight so Pneuma engineers focus on orchestration and configuration rather than raw tooling.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🔴 5 / 4 | 🟠 3 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Cluster Management | 🔴 High | Arche GKE module | GKE internals, Fleet enrollment |
+| Service Mesh | 🔴 High | Arche Istio module | mTLS, traffic policy |
+| Certificate Management | 🔴 High | Arche cert-manager module | PKI chains, issuers |
+| Policy Enforcement | 🟡 Medium | Arche OPA module | Rego, constraint authoring |
+| Observability | 🟡 Medium | Arche Datadog module | Cluster metrics & traces |
+
+**Capacity**: 3 high-complexity domains — at the Team Topologies guideline of 2–3; team members hold 5 active domains — above the ~4 working-knowledge limit. Arche Kubernetes modules are the primary mitigation: all Helm-based add-on deployment is encapsulated, leaving Pneuma to own configuration and integration rather than implementation.
+
+**Extraneous load is minimized by:**
+
+- Arche Kubernetes modules (`pt-arche-kubernetes-*`) wrap Istio, cert-manager, OPA Gatekeeper, and the Datadog Operator — no raw Helm chart management
+- Corpus handles all networking prerequisites; Pneuma consumes them via `module.core_helpers`
+- All state is managed exclusively in GitHub Actions — no local backend access required
+
+**Germane load is built through:**
+
+- Cloud-native orchestration: GKE internals, autoscaling, Workload Identity, and Fleet enrollment
+- Zero-trust networking: Istio mTLS, traffic policy, and Datadog AAP integration
+- Applied PKI: ECDSA root CA chains, cert-manager issuers, and istio-csr for mesh certificate signing
+- Policy-as-code: Rego constraint authoring and audit-mode enforcement patterns
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | 1–2 domain engineers |
+| **Day-to-day work** | GKE cluster operations, Kubernetes add-on upgrades, networking support for stream-aligned teams |
+| **Scale signal** | Add a second engineer when cluster count grows or multiple add-on upgrades run in parallel — the one team where headcount scales with the platform |

--- a/docs/platform-teams/pneuma/service-mesh.md
+++ b/docs/platform-teams/pneuma/service-mesh.md
@@ -18,6 +18,6 @@ Istio is deployed on every GKE cluster, providing mTLS between services, fine-gr
 | `istio-control-plane` | The Istio control plane deployed via Helm, managing traffic policy across the mesh |
 | `ingress-gateway` | A managed ingress gateway exposed via a GCP load balancer |
 | `waf-policy` | A Cloud Armor security policy attached to the ingress gateway (OWASP rules, rate limiting, adaptive DDoS) |
-| `virtual-service` | An Istio routing rule defining traffic behaviour for a service (retries, timeouts, fault injection) |
+| `virtual-service` | An Istio routing rule defining traffic behavior for a service (retries, timeouts, fault injection) |
 | `destination-rule` | An Istio policy defining connection pool and circuit breaker settings for a destination |
 | `peer-authentication` | A mesh-wide policy enforcing strict mTLS between all services |

--- a/docs/platform-teams/techne/index.md
+++ b/docs/platform-teams/techne/index.md
@@ -7,7 +7,7 @@ description: The practiced art of making — the disciplined craft through which
 
 Techne is the practiced art of making — the disciplined craft through which raw materials of infrastructure are shaped into purposeful, refined platform instruments.
 
-Techne operates as the platform's conformist tooling layer: versioned GitHub Actions called workflows, pre-commit hooks, and developer tooling published on GitHub and consumed by every platform repo as pinned dependencies. See the [conformist tooling ADR](#techne-as-a-conformist-platform-tooling-layer) for the rationale.
+Techne operates as the platform's shared kernel tooling layer: versioned GitHub Actions called workflows, pre-commit hooks, and developer tooling published on GitHub and consumed by platform and stream-aligned repositories as pinned dependencies. Any team can contribute improvements — changes to shared interfaces are coordinated with consumers. See the [shared kernel ADR](#techne-as-a-shared-kernel-platform-tooling-layer) for the rationale.
 
 :::tip Architecture Decision Records
 
@@ -29,24 +29,70 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 ## Domain
 
-Techne operates using a **Conformist** pattern in the [context map](/platform-teams#context-map) — all platform teams adopt its workflows, hooks, and tooling as-is. There is no negotiation of interfaces.
+Techne operates using a **Shared Kernel** pattern in the [context map](/platform-teams#context-map) — all teams share its workflows, hooks, and tooling as a jointly maintained foundation. Unlike a pure Conformist, interface changes are coordinated with consumers, and any team can contribute improvements via pull request. The Platform Lead holds final approval authority on interface changes due to the blast radius across all consumers.
 
-**Ubiquitous Language:** workflow, job, OIDC, pre-commit hook, codespace, toolchain
+### Ubiquitous Language
+
+| Term | Meaning in this domain |
+|---|---|
+| Codespace | A GitHub-hosted development environment defined in `pt-techne-opentofu-codespace` |
+| Job | A single GitHub Actions execution unit within a workflow (e.g., sandbox, non-production, production) |
+| OIDC | OpenID Connect — the token-based authentication protocol that eliminates static credentials from CI |
+| Pre-commit hook | A script in `pt-techne-pre-commit-hooks` that runs automatically before every git commit |
+| Toolchain | The complete set of CLIs and tools (tofu, pre-commit, gh) standardized across all repositories |
+| Workflow | A GitHub Actions called workflow in `pt-techne-opentofu-workflows` consumed via `workflow_call` |
 
 ### Bounded Contexts
 
 | Bounded Context | Artifacts | Consumed By |
 |---|---|---|
 | [Deployment Automation](./deployment-automation.md) | Called workflows, OIDC auth, state config, job summaries | All platform teams |
-| [Developer Experience](./developer-experience.md) | Codespace, pre-commit hooks, development setup | All platform teams |
+| [Developer Experience](./developer-experience.md) | Codespace, pre-commit hooks, development setup | All platform and stream-aligned teams |
 
 ### Core Invariant
 
 All deployments use short-lived OIDC tokens — no static credentials exist anywhere on the platform.
 
+### Cognitive Load
+
+Techne's domains are medium and low complexity individually — the craft is in designing tooling that reliably reduces extraneous load for every other team on the platform. A bug in a Techne called workflow or hook can affect all consumers simultaneously.
+
+| Working Domains | High Intrinsic Domains |
+|---|---|
+| 🟢 2 / 4 | 🟢 0 / 3 |
+
+Cognitive load by domain:
+
+| Domain | Intrinsic | Extraneous Reduced By | Germane Expertise |
+|---|---|---|---|
+| Deployment Automation | 🟡 Medium | Reusable called workflows | GitHub Actions, OIDC patterns |
+| Developer Experience | 🟢 Low | Pre-commit automation | DevX & productivity design |
+
+**Capacity**: 0 high-complexity domains (Team Topologies guideline: 2–3); team members hold 2 active domains — well within the ~4 working-knowledge limit.
+
+**Extraneous load is minimized by:**
+
+- Reusable called workflows mean no platform team implements its own deployment pipeline
+- Pre-commit hooks enforce standards automatically across all repos on every commit
+- OIDC authentication eliminates static credentials entirely — no rotation burden on any team
+
+**Germane load is built through:**
+
+- GitHub Actions ecosystem: called workflow design, input/output contracts, and backward compatibility
+- CI/CD security patterns: OIDC federation, least-privilege service accounts, and short-lived tokens
+- Developer productivity: understanding what friction platform and stream-aligned engineers actually encounter and systematically removing it
+
+### Team Capacity
+
+| | |
+|---|---|
+| **Headcount** | Inner source — no dedicated engineer |
+| **Contribution model** | Any team can contribute improvements; the Platform Lead holds final approval on interface changes due to blast radius across all consumers |
+| **Scale signal** | Stable once built — the platform lead or a senior engineer handles occasional updates |
+
 ## Architecture Decision Records
 
-### Techne as a Conformist Platform Tooling Layer
+### Techne as a Shared Kernel Platform Tooling Layer
 
 <table>
   <thead>
@@ -59,19 +105,19 @@ All deployments use short-lived OIDC tokens — no static credentials exist anyw
 
 #### Context and Problem Statement
 
-Every platform repository needs the same foundational tooling: consistent OpenTofu deployment pipelines (OIDC auth, KMS-encrypted state, job summaries), pre-commit validation hooks, and a standardized developer environment. Without a shared approach, each repo would implement these independently, leading to drift and duplicated maintenance across dozens of repositories.
+Every platform repository needs consistent OpenTofu deployment pipelines (OIDC auth, KMS-encrypted state, job summaries) and pre-commit validation hooks. All repositories — platform and stream-aligned — benefit from a standardized developer environment and shared toolchain. Without a shared approach, each repository would implement these independently, leading to drift and duplicated maintenance.
 
-This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type and domain relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
+This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Shared Kernel; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Decision
 
-Organize all shared platform tooling as a conformist platform layer under the `pt-techne-*` namespace. Each repository is:
+Organize all shared tooling as a shared kernel layer under the `pt-techne-*` namespace. Each repository is:
 
 - A standalone GitHub repository with its own versioning and release pipeline
 - Consumed by callers via pinned references (commit SHAs for actions, tagged versions for hooks)
-- Owned by the Techne team and open for contribution from any platform team
+- Owned by the Techne team and open for contribution from any team
 
-The scope of consumers is broader than Arche — every platform repository uses Techne tooling, not just the three infrastructure domains.
+The scope of consumers is broader than Arche — Techne developer experience tooling (Codespace, pre-commit hooks, development setup) is consumed by all platform and stream-aligned teams, not just the infrastructure domains. Deployment automation is platform-team scoped.
 
 #### Alternatives Considered
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,7 +65,9 @@ const sidebars = {
           type: 'category',
           label: 'Kryptos',
           link: { type: 'doc', id: 'platform-teams/kryptos/index' },
-          items: [],
+          items: [
+            'platform-teams/kryptos/open-bao',
+          ],
         },
         {
           type: 'category',


### PR DESCRIPTION
## Summary

Adds comprehensive Team Topologies domain documentation across all 7 platform team pages and the platform overview.

## Changes

### Platform overview (`docs/platform-teams/index.md`)
- Added context map flowchart with Customer/Supplier, Shared Kernel, and Knowledge relationships
- Added cognitive load heat table with colour legend
- Added Team Capacity section covering Platform Lead role, domain engineers per team, and inner source model

### All 7 platform team pages
Each team page now has a consistent `## Domain` section with these subheadings in order:
1. `### Ubiquitous Language` — alphabetical term/definition table
2. `### Downstream Interfaces` or `### Bounded Contexts` — artifact-to-consumer mapping
3. `### Core Invariant` — the one rule that must never be violated
4. `### Cognitive Load` — heat table, domain-by-domain analysis, extraneous/germane load
5. `### Team Capacity` — 3-row table: headcount, day-to-day work, scale signal

### Techne reclassified
Reclassified from **Conformist** to **Shared Kernel** — Techne tooling exists to serve consumers, interface changes are coordinated, and any team can contribute. ADR, domain section, and context map updated accordingly. Techne's broader consumer scope (all teams, not just platform teams) is now accurately reflected throughout.

### Kryptos additions
- Added `### Downstream Interfaces` table (was missing)
- Added OpenBao sub-page covering Kubernetes auth, PKI, KV, and database engine
- Registered in `sidebars.js`

### Instructions
- Codified domain section subheading order in `.github/copilot-instructions.md` so new team pages follow the same structure

### Fixes
- American English spelling throughout (`organisation` → `organization`, `behaviour` → `behavior`)
- Staffing numbers grounded in cognitive load analysis, not hypothetical org size
- Stream-aligned team contributor scope corrected on Techne and Ekklesia pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized platform-team pages with prescribed subsections: Ubiquitous Language (term tables), Downstream Interfaces/Bounded Contexts, optional Core Invariant, Cognitive Load, and Team Capacity.
  * Converted many term lists into definition tables and added cognitive-load and capacity guidance across domains.
  * Added OpenBao secrets management docs.
  * Reworked platform relationship language (Techne as Shared Kernel) and updated navigation/sidebar entries.
  * Minor spelling and editorial refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->