### PR TITLE
Correct Techne DDD pattern label from Conformist to Shared Kernel

### DIFF
--- a/docs/platform-teams/arche/index.md
+++ b/docs/platform-teams/arche/index.md
@@ -132,7 +132,7 @@ Modules are decomposed into two bounded contexts reflecting their infrastructure
 
 This decomposition maps directly to the deployment layers in Corpus (GCP) and Pneuma (Kubernetes), making it clear which modules each domain consumes.
 
-A similar inner-source contribution model is used by [Techne](/platform-teams/techne#techne-as-a-conformist-platform-tooling-layer) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type and domain relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
+A similar inner-source contribution model is used by [Techne](/platform-teams/techne#techne-as-a-shared-kernel-platform-tooling-layer) and [Ekklesia](/platform-teams/ekklesia#ekklesia-as-the-platforms-shared-knowledge-domain) — the difference is artifact type and domain relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration as a Shared Kernel; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Alternatives Considered
 

--- a/docs/platform-teams/ekklesia/index.md
+++ b/docs/platform-teams/ekklesia/index.md
@@ -96,7 +96,7 @@ Cognitive load by domain:
 
 Platform knowledge — architecture decisions, module usage, deployment patterns, operational guides — is spread across multiple teams and repositories. Without a shared home, documentation lives in README files that are hard to navigate, per-team wikis that fall out of sync, or not at all. Engineers must hunt across repositories to understand how the platform fits together.
 
-This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Techne](/platform-teams/techne#techne-as-a-conformist-platform-tooling-layer) — the difference is artifact type and domain relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions workflows and tooling as a Conformist; Ekklesia shares documentation as a Shared Knowledge Domain.
+This follows a similar inner-source contribution model to [Arche](/platform-teams/arche#arche-as-an-inner-source-shared-kernel) and [Techne](/platform-teams/techne#techne-as-a-shared-kernel-platform-tooling-layer) — the difference is artifact type and domain relationship pattern. Arche shares OpenTofu modules as a Shared Kernel; Techne shares GitHub Actions workflows and tooling as a Shared Kernel; Ekklesia shares documentation as a Shared Knowledge Domain.
 
 #### Decision
 


### PR DESCRIPTION
Closes #47

## Changes

The Arche and Ekklesia ADRs incorrectly labeled Techne as a **Conformist** when cross-referencing it. `techne/index.md` already uses **Shared Kernel** consistently throughout. This PR aligns the other two pages to match.

### `docs/platform-teams/arche/index.md`

- Updated ADR cross-reference: `as a Conformist` → `as a Shared Kernel`
- Fixed anchor link: `#techne-as-a-conformist-platform-tooling-layer` → `#techne-as-a-shared-kernel-platform-tooling-layer`

### `docs/platform-teams/ekklesia/index.md`

- Updated ADR cross-reference: `as a Conformist` → `as a Shared Kernel`
- Fixed anchor link: `#techne-as-a-conformist-platform-tooling-layer` → `#techne-as-a-shared-kernel-platform-tooling-layer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform architecture documentation to clarify Techne's inner-source contribution model relationship pattern across multiple reference pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->