### PR TITLE
Add consumer contract section to networking page

### DIFF
--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -145,7 +145,7 @@ A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP confl
 
 When the active block reaches 25 claimed slots, the Corpus team initiates a capacity review to activate the next `/10` block before the remaining 5 slots are exhausted.
 
-To provision a new cluster, open a pull request in [pt-logos](https://github.com/osinfra-io/pt-logos) assigning the next available CIDR slot to the new cluster. The Corpus team owns IPAM monitoring and approves all slot allocations.
+To provision a new cluster, use the [Logos Agent](https://github.com/osinfra-io/pt-logos/blob/main/.github/agents/logos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
 
 ## Domain
 

--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -133,7 +133,7 @@ This block is available for future use.
 
 ## Consumer Contract
 
-A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. **22 more clusters can be provisioned from the active `10.0.0.0/10` block before the next block must be activated; 112 more before the entire IPAM plan requires redesign.**
+A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. **22 more clusters can be provisioned from the active `10.0.0.0/10` block before the IPAM plan must be expanded; 112 more before the entire plan requires redesign.**
 
 | Metric | Value |
 |---|---|
@@ -141,9 +141,9 @@ A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP confl
 | Slots in use | 8 of 30 |
 | Slots remaining (active block) | 22 |
 | Total capacity (all 4 blocks) | 120 clusters |
-| Capacity review threshold | 25 of 30 slots claimed in the active block |
+| Plan expansion required at | 30 of 30 slots claimed in the active block |
 
-When the active block reaches 25 claimed slots, the Corpus team initiates a capacity review to activate the next `/10` block before the remaining 5 slots are exhausted.
+When all 30 slots in the active block are claimed, the Logos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
 
 To provision a new cluster, use the [Logos Agent](https://github.com/osinfra-io/pt-logos/blob/main/.github/agents/logos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
 

--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -133,17 +133,7 @@ This block is available for future use.
 
 ## Consumer Contract
 
-A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. **22 more clusters can be provisioned from the active `10.0.0.0/10` block before the IPAM plan must be expanded; 112 more before the entire plan requires redesign.**
-
-| Metric | Value |
-|---|---|
-| Active block | `10.0.0.0/10` |
-| Slots in use | 8 of 30 |
-| Slots remaining (active block) | 22 |
-| Total capacity (all 4 blocks) | 120 clusters |
-| Plan expansion required at | 30 of 30 slots claimed in the active block |
-
-When all 30 slots in the active block are claimed, the Logos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
+A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. The plan supports up to 30 clusters per `/10` block and 120 clusters total across all four blocks. When all 30 slots in the active block are claimed, the Logos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
 
 To provision a new cluster, use the [Logos Agent](https://github.com/osinfra-io/pt-logos/blob/main/.github/agents/logos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
 

--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -131,6 +131,22 @@ This block is available for future use.
   </TabItem>
 </Tabs>
 
+## Consumer Contract
+
+A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. **22 more clusters can be provisioned from the active `10.0.0.0/10` block before the next block must be activated; 112 more before the entire IPAM plan requires redesign.**
+
+| Metric | Value |
+|---|---|
+| Active block | `10.0.0.0/10` |
+| Slots in use | 8 of 30 |
+| Slots remaining (active block) | 22 |
+| Total capacity (all 4 blocks) | 120 clusters |
+| Capacity review threshold | 25 of 30 slots claimed in the active block |
+
+When the active block reaches 25 claimed slots, the Corpus team initiates a capacity review to activate the next `/10` block before the remaining 5 slots are exhausted.
+
+To provision a new cluster, open a pull request in [pt-logos](https://github.com/osinfra-io/pt-logos) assigning the next available CIDR slot to the new cluster. The Corpus team owns IPAM monitoring and approves all slot allocations.
+
 ## Domain
 
 | Entity | Description |


### PR DESCRIPTION
Closes #45

Adds a `## Consumer Contract` section to the networking page between the IPAM detail and the Domain section. The new section answers the consumer-facing questions from the issue:

- Current utilization: 8 of 30 slots in the active `10.0.0.0/10` block
- Total capacity: 120 clusters across all four `/10` blocks (112 remaining)
- Capacity review threshold: 25 of 30 slots claimed
- Who owns IPAM and how to claim a slot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Consumer Contract for GKE cluster networking that guarantees pre-allocated CIDR slots and defines allocation limits (30 per block, 120 total).
  * Introduced an operational rule to advance to the next allocation block when a block is fully claimed.
  * Documented an automated provisioning workflow where the agent selects the next available CIDR slot and opens the required pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->