### PR TITLE
Update Datadog observability docs to reflect platform invariants and APM opt-in

### DIFF
--- a/docs/platform-teams/arche/kubernetes.md
+++ b/docs/platform-teams/arche/kubernetes.md
@@ -31,7 +31,7 @@ Kubernetes add-on modules for service mesh, certificate management, policy enfor
     <ModuleCard
       image="/img/datadog.png"
       title="pt-arche-kubernetes-datadog-operator"
-      description="OpenTofu module that deploys the Datadog Operator via Helm and manages a DatadogAgent custom resource with configurable observability features including log collection, NPM, USM, Orchestrator Explorer, SBOM, and optional APM and security modules"
+      description="OpenTofu module that deploys the Datadog Operator via Helm and manages a DatadogAgent custom resource. Platform invariants — log collection, NPM, Orchestrator Explorer, SBOM, CSPM, and CWS — are always enabled. APM and Universal Service Monitoring are opt-in per team via the Logos schema."
       href="https://github.com/osinfra-io/pt-arche-kubernetes-datadog-operator"
     />
   </div>

--- a/docs/platform-teams/arche/kubernetes.md
+++ b/docs/platform-teams/arche/kubernetes.md
@@ -31,7 +31,7 @@ Kubernetes add-on modules for service mesh, certificate management, policy enfor
     <ModuleCard
       image="/img/datadog.png"
       title="pt-arche-kubernetes-datadog-operator"
-      description="OpenTofu module that deploys the Datadog Operator via Helm and manages a DatadogAgent custom resource. Platform invariants — log collection, NPM, Orchestrator Explorer, SBOM, CSPM, and CWS — are always enabled. APM and Universal Service Monitoring are opt-in per team via the Logos schema."
+      description="OpenTofu module that deploys the Datadog Operator via Helm and manages a DatadogAgent custom resource. Platform invariants — Admission Controller, Workload Autoscaling, log collection, NPM, Orchestrator Explorer, SBOM, CSPM, and CWS — are always enabled. APM and Universal Service Monitoring are opt-in per team via the Logos schema."
       href="https://github.com/osinfra-io/pt-arche-kubernetes-datadog-operator"
     />
   </div>

--- a/docs/platform-teams/pneuma/observability.md
+++ b/docs/platform-teams/pneuma/observability.md
@@ -6,22 +6,34 @@ sidebar_label: Observability
 
 The Datadog Operator runs on every GKE cluster and manages the Datadog Agent DaemonSet via a `DatadogAgent` custom resource. The operator authenticates using per-team API and app keys provisioned by Logos and injected as GitHub Actions secrets.
 
-## Always-on features
+## Platform invariants
 
-These features are hardcoded enabled in the `DatadogAgent` spec:
+These features are hardcoded enabled in the `DatadogAgent` spec and cannot be disabled by individual teams:
 
 - **Admission Controller**: Mutates application pods at admission time to inject the Datadog library and environment variables, enabling traces, logs, and metrics to reach the agent without code changes
 - **Workload Autoscaling**: Implements the Kubernetes external metrics API so HPAs can scale workloads on Datadog metrics
-
-## Default-enabled features
-
-These features are on by default but can be disabled:
-
 - **Log collection**: Collects stdout/stderr logs from all containers with automatic Kubernetes metadata enrichment
 - **Network Performance Monitoring (NPM)**: Tracks network traffic between services using eBPF — bytes sent/received, TCP retransmits, connection counts — without instrumentation
-- **Universal Service Monitoring (USM)**: Automatically detects service-to-service communication via eBPF and generates RED metrics (requests, errors, duration) per service without code changes
 - **Orchestrator Explorer**: Provides a live view of Kubernetes resources (pods, deployments, services, nodes) in the Datadog UI, equivalent to a real-time kubectl dashboard
-- **Software Bill of Materials (SBOM)**: Scans container images and generates an inventory of OS packages and libraries with version and CVE status
+- **Software Bill of Materials (SBOM)**: Scans container images and host filesystems and generates an inventory of OS packages and libraries with version and CVE status
+- **Cloud Security Posture Management (CSPM)**: Evaluates cloud resource configurations against security benchmarks (CIS, PCI-DSS, etc.)
+- **Cloud Workload Security (CWS)**: Detects runtime threats at the OS level using eBPF kernel event monitoring, with network detection also enabled
+
+## Team-opt-in features
+
+These features are disabled by default and enabled per team via the `kubernetes_engine.enable_datadog_apm` flag in the Logos team schema:
+
+- **APM**: Distributed tracing — collects spans from instrumented services and assembles flame graphs and service maps ($31/host/month annual with Infrastructure Monitoring)
+- **Universal Service Monitoring (USM)**: Automatically detects service-to-service communication via eBPF and generates RED metrics (requests, errors, duration) per service without code changes — enabled automatically alongside APM at no additional cost
+
+## Optional features
+
+These features are disabled by default and carry additional per-host cost when enabled. They are configured as module inputs in pt-pneuma:
+
+- **APM Single-Step Instrumentation**: Auto-instruments all eligible pods at admission time without requiring code changes; requires APM
+- **App & API Protection (ASM Threats)**: Runtime application security — detects and blocks attacks in real time using the Datadog Agent
+- **Interactive Application Security Testing (IAST)**: Finds exploitable vulnerabilities in running application code
+- **Software Composition Analysis (SCA)**: Identifies vulnerable open-source dependencies in deployed container images
 
 ## Integrations
 
@@ -29,18 +41,6 @@ Autodiscovery rules are pre-configured for the following cluster components:
 
 - **Cilium**: Scrapes Cilium eBPF dataplane metrics from the agent endpoint using OpenMetrics
 - **Envoy (Istio sidecars)**: Scrapes Envoy proxy metrics from the Istio stats endpoint and collects Envoy access logs
-
-## Optional features
-
-These features are disabled by default and carry additional per-host cost when enabled:
-
-- **APM**: Distributed tracing — collects spans from instrumented services and assembles flame graphs and service maps
-- **APM Single-Step Instrumentation**: Auto-instruments all eligible pods at admission time without requiring code changes
-- **App & API Protection (ASM Threats)**: Runtime application security — detects and blocks attacks in real time using the Datadog Agent
-- **Interactive Application Security Testing (IAST)**: Finds exploitable vulnerabilities in running application code
-- **Software Composition Analysis (SCA)**: Identifies vulnerable open-source dependencies in deployed container images
-- **Cloud Security Posture Management (CSPM)**: Evaluates cloud resource configurations against security benchmarks (CIS, PCI-DSS, etc.)
-- **Cloud Workload Security (CWS)**: Detects runtime threats at the OS level using eBPF kernel event monitoring
 
 ## Aggregate
 

--- a/docs/platform-teams/pneuma/observability.md
+++ b/docs/platform-teams/pneuma/observability.md
@@ -21,7 +21,7 @@ These features are hardcoded enabled in the `DatadogAgent` spec and cannot be di
 
 ## Team-opt-in features
 
-These features are disabled by default and enabled per team via the `kubernetes_engine.enable_datadog_apm` flag in the Logos team schema:
+These features are disabled by default and enabled per team via the `platform_managed_project.kubernetes_engine.enable_datadog_apm` flag in the Logos team schema:
 
 - **APM**: Distributed tracing — collects spans from instrumented services and assembles flame graphs and service maps ($31/host/month annual with Infrastructure Monitoring)
 - **Universal Service Monitoring (USM)**: Automatically detects service-to-service communication via eBPF and generates RED metrics (requests, errors, duration) per service without code changes — enabled automatically alongside APM at no additional cost

--- a/src/components/SchemaViewer/logosTeamSchema.js
+++ b/src/components/SchemaViewer/logosTeamSchema.js
@@ -351,6 +351,12 @@ const logosTeamSchema = {
             description:
               'DNS subdomain for team services. Defaults to the team key with prefix removed. Creates zones: {subdomain}.osinfra.io, {subdomain}.nonprod.osinfra.io, {subdomain}.sb.osinfra.io.',
           },
+          enable_datadog_apm: {
+            type: 'boolean',
+            required: false,
+            description:
+              'Enables Datadog APM (distributed tracing) and Universal Service Monitoring (USM) on the team\'s GKE cluster. USM is included at no extra cost when APM is enabled. Only meaningful when platform_managed_project.enable_datadog is true. Cost: $31/host/month (annual) with Infrastructure Monitoring. Default: false.',
+          },
           artifact_registry_groups_memberships: {
             type: 'object',
             required: false,


### PR DESCRIPTION
Reflects the architectural changes from pt-arche-kubernetes-datadog-operator v0.3.8 and the new `enable_datadog_apm` flag in pt-logos.

## Changes

**`docs/platform-teams/pneuma/observability.md`**
- Replaced "Always-on" + "Default-enabled" sections with a single **Platform invariants** section covering all 8 hardcoded features: Admission Controller, Workload Autoscaling, Log Collection, NPM, Orchestrator Explorer, SBOM, CSPM, CWS (+ network)
- Added **Team-opt-in features** section: APM and USM, enabled via `kubernetes_engine.enable_datadog_apm` in Logos; includes cost note ($31/host/month)
- **Optional features** section trimmed to what's actually optional: APM Single-Step Instrumentation, ASM Threats, IAST, SCA

**`src/components/SchemaViewer/logosTeamSchema.js`**
- Added `enable_datadog_apm` inside `kubernetes_engine` (after `dns_subdomain`), with description and cost note

**`docs/platform-teams/arche/kubernetes.md`**
- Updated the `pt-arche-kubernetes-datadog-operator` ModuleCard description to reflect invariants vs opt-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured Datadog observability documentation to clarify platform invariants (always-enabled features) versus team opt-in capabilities.
  * Updated documentation to specify which observability features are configurable per team.

* **New Features**
  * Added configuration option for teams to enable Datadog APM on Kubernetes clusters, which automatically includes Universal Service Monitoring at no additional cost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->