### PR TITLE
Add Data to the docs site

### DIFF
--- a/docs/stream-aligned-teams/data/index.md
+++ b/docs/stream-aligned-teams/data/index.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Data
+description: The stream-aligned team responsible for data products and analytics that power decision-making across the business.
+---
+
+# Data
+
+The stream-aligned team responsible for data products and analytics that power decision-making across the business.

--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -54,5 +54,6 @@ Logos runs OpenTofu on merge — the GCP folder hierarchy, identity groups, and 
 ## Teams
 
 <CardGrid>
+  <Card item={{ icon: '📊', title: 'Data', note: 'The stream-aligned team responsible for data products and analytics that power decision-making across the business.', link: '/stream-aligned-teams/data', linkText: 'Learn more →' }} />
   <Card item={{ icon: '🧭', title: 'Ethos', note: 'The lived moral character that customers experience — the trustworthiness, transparency, and integrity through which the business earns and keeps their confidence.', link: '/stream-aligned-teams/ethos', linkText: 'Learn more →' }} />
 </CardGrid>

--- a/sidebars.js
+++ b/sidebars.js
@@ -87,6 +87,12 @@ const sidebars = {
       items: [
         {
           type: 'category',
+          label: 'Data',
+          link: { type: 'doc', id: 'stream-aligned-teams/data/index' },
+          items: [],
+        },
+        {
+          type: 'category',
           label: 'Ethos',
           link: { type: 'doc', id: 'stream-aligned-teams/ethos/index' },
           items: [],


### PR DESCRIPTION
Adds the new **Data** stream-aligned team to the docs site:\n\n- New `<Card>` in `docs/stream-aligned-teams/index.md` (alphabetical, before Ethos)\n- New `docs/stream-aligned-teams/data/index.md` page with front matter and intro\n- Sidebar entry inserted into `Stream-Aligned Teams` (alphabetical, before Ethos)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page for the Data stream-aligned team, detailing their responsibility for data products and analytics supporting business decision-making
  * Introduced navigation links to access the Data team documentation across the site

<!-- end of auto-generated comment: release notes by coderabbit.ai -->