### PR TITLE
Add region anchor comments to sidebars.js

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,5 +1,10 @@
 // @ts-check
 
+// The `// region: <section>` / `// endregion: <section>` markers below are
+// consumed by `pt-techne-mcp-server`'s `render_sidebar_patch` tool, which
+// inserts new team entries between them. Keep them in place; deleting or
+// renaming a marker will cause that tool to fail with `source_parse_error`.
+
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   docs: [
@@ -8,6 +13,7 @@ const sidebars = {
       label: 'Platform Teams',
       link: { type: 'doc', id: 'platform-teams/index' },
       items: [
+        // region: platform-teams
         {
           type: 'category',
           label: 'Logos',
@@ -78,6 +84,7 @@ const sidebars = {
             'platform-teams/techne/developer-experience',
           ],
         },
+        // endregion: platform-teams
       ],
     },
     {
@@ -85,12 +92,14 @@ const sidebars = {
       label: 'Stream-Aligned Teams',
       link: { type: 'doc', id: 'stream-aligned-teams/index' },
       items: [
+        // region: stream-aligned-teams
         {
           type: 'category',
           label: 'Ethos',
           link: { type: 'doc', id: 'stream-aligned-teams/ethos/index' },
           items: [],
         },
+        // endregion: stream-aligned-teams
       ],
     },
     {
@@ -98,12 +107,14 @@ const sidebars = {
       label: 'Complicated Subsystem Teams',
       link: { type: 'doc', id: 'complicated-subsystem-teams/index' },
       items: [
+        // region: complicated-subsystem-teams
         {
           type: 'category',
           label: 'Mysterion',
           link: { type: 'doc', id: 'complicated-subsystem-teams/mysterion/index' },
           items: [],
         },
+        // endregion: complicated-subsystem-teams
       ],
     },
     {
@@ -111,6 +122,7 @@ const sidebars = {
       label: 'Enabling Teams',
       link: { type: 'doc', id: 'enabling-teams/index' },
       items: [
+        // region: enabling-teams
         {
           type: 'category',
           label: 'Sophrosyne',
@@ -123,6 +135,7 @@ const sidebars = {
           link: { type: 'doc', id: 'enabling-teams/soteria/index' },
           items: [],
         },
+        // endregion: enabling-teams
       ],
     },
   ],


### PR DESCRIPTION
Adds `// region: <section>` / `// endregion: <section>` anchor markers around each top-level section's `items` list in `sidebars.js`, plus a top-of-file comment explaining the convention.

These markers are consumed by `pt-techne-mcp-server`'s upcoming `render_sidebar_patch` tool ([osinfra-io/pt-techne-mcp-server#8](https://github.com/osinfra-io/pt-techne-mcp-server/issues/8)), which inserts new team entries between them.

This is a no-op for Docusaurus — JS comments don't affect the generated sidebar.

## Why anchor comments

The renderer needs deterministic insertion points. Two options were considered:

- Anchor comments (this PR) — cheap, debuggable, no JS parser in the Go server.
- Parse `sidebars.js` as a JS AST — exact, but pulls a JS parser into the Go server.

We're going with anchor comments first. The AST alternative is tracked as a follow-up should the markers prove too fragile in practice.

## Maintenance

If a marker is deleted or renamed, `render_sidebar_patch` will return a structured `source_parse_error` and refuse to write. The top-of-file comment makes the convention discoverable from inside the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced sidebar structure to support expanded team configurations across multiple sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->