### PR TITLE
Add Foo to the docs site

### DIFF
--- a/docs/platform-teams/corpus/networking.md
+++ b/docs/platform-teams/corpus/networking.md
@@ -55,7 +55,7 @@ VPC: standard-shared
 </details>
 
 <Tabs>
-  <TabItem value="active" label="Active Clusters (8)" default>
+  <TabItem value="active" label="Active Clusters (9)" default>
 
     <CardGrid>
       <NetworkCard cluster="pt-pneuma-us-east1-b" logo="/img/gke.svg" primary="10.60.0.0/20" pods="10.0.0.0/15" services="10.61.224.0/20" master="10.63.192.0/28" />
@@ -66,34 +66,34 @@ VPC: standard-shared
       <NetworkCard cluster="pt-pneuma-us-east4-c" logo="/img/gke.svg" primary="10.60.80.0/20" pods="10.10.0.0/15" services="10.62.48.0/20" master="10.63.192.80/28" />
       <NetworkCard cluster="pt-kryptos-us-east1-b" logo="/img/gke.svg" primary="10.60.96.0/20" pods="10.12.0.0/15" services="10.62.64.0/20" master="10.63.192.96/28" />
       <NetworkCard cluster="pt-kryptos-us-east4-a" logo="/img/gke.svg" primary="10.60.112.0/20" pods="10.14.0.0/15" services="10.62.80.0/20" master="10.63.192.112/28" />
+      <NetworkCard cluster="st-foo-us-east4-b" logo="/img/gke.svg" primary="10.60.128.0/20" pods="10.16.0.0/15" services="10.62.96.0/20" master="10.63.192.128/28" />
     </CardGrid>
 
   </TabItem>
-  <TabItem value="available" label="Available Slots (22)">
+  <TabItem value="available" label="Available Slots (21)">
 
     <CardGrid>
-      <NetworkCard cluster="Available – Slot 09" primary="10.60.128.0/20" pods="10.16.0.0/15" services="10.62.96.0/20" master="10.63.192.128/28" />
-      <NetworkCard cluster="Available – Slot 10" primary="10.60.144.0/20" pods="10.18.0.0/15" services="10.62.112.0/20" master="10.63.192.144/28" />
-      <NetworkCard cluster="Available – Slot 11" primary="10.60.160.0/20" pods="10.20.0.0/15" services="10.62.128.0/20" master="10.63.192.160/28" />
-      <NetworkCard cluster="Available – Slot 12" primary="10.60.176.0/20" pods="10.22.0.0/15" services="10.62.144.0/20" master="10.63.192.176/28" />
-      <NetworkCard cluster="Available – Slot 13" primary="10.60.192.0/20" pods="10.24.0.0/15" services="10.62.160.0/20" master="10.63.192.192/28" />
-      <NetworkCard cluster="Available – Slot 14" primary="10.60.208.0/20" pods="10.26.0.0/15" services="10.62.176.0/20" master="10.63.192.208/28" />
-      <NetworkCard cluster="Available – Slot 15" primary="10.60.224.0/20" pods="10.28.0.0/15" services="10.62.192.0/20" master="10.63.192.224/28" />
-      <NetworkCard cluster="Available – Slot 16" primary="10.60.240.0/20" pods="10.30.0.0/15" services="10.62.208.0/20" master="10.63.192.240/28" />
-      <NetworkCard cluster="Available – Slot 17" primary="10.61.0.0/20" pods="10.32.0.0/15" services="10.62.224.0/20" master="10.63.193.0/28" />
-      <NetworkCard cluster="Available – Slot 18" primary="10.61.16.0/20" pods="10.34.0.0/15" services="10.62.240.0/20" master="10.63.193.16/28" />
-      <NetworkCard cluster="Available – Slot 19" primary="10.61.32.0/20" pods="10.36.0.0/15" services="10.63.0.0/20" master="10.63.193.32/28" />
-      <NetworkCard cluster="Available – Slot 20" primary="10.61.48.0/20" pods="10.38.0.0/15" services="10.63.16.0/20" master="10.63.193.48/28" />
-      <NetworkCard cluster="Available – Slot 21" primary="10.61.64.0/20" pods="10.40.0.0/15" services="10.63.32.0/20" master="10.63.193.64/28" />
-      <NetworkCard cluster="Available – Slot 22" primary="10.61.80.0/20" pods="10.42.0.0/15" services="10.63.48.0/20" master="10.63.193.80/28" />
-      <NetworkCard cluster="Available – Slot 23" primary="10.61.96.0/20" pods="10.44.0.0/15" services="10.63.64.0/20" master="10.63.193.96/28" />
-      <NetworkCard cluster="Available – Slot 24" primary="10.61.112.0/20" pods="10.46.0.0/15" services="10.63.80.0/20" master="10.63.193.112/28" />
-      <NetworkCard cluster="Available – Slot 25" primary="10.61.128.0/20" pods="10.48.0.0/15" services="10.63.96.0/20" master="10.63.193.128/28" />
-      <NetworkCard cluster="Available – Slot 26" primary="10.61.144.0/20" pods="10.50.0.0/15" services="10.63.112.0/20" master="10.63.193.144/28" />
-      <NetworkCard cluster="Available – Slot 27" primary="10.61.160.0/20" pods="10.52.0.0/15" services="10.63.128.0/20" master="10.63.193.160/28" />
-      <NetworkCard cluster="Available – Slot 28" primary="10.61.176.0/20" pods="10.54.0.0/15" services="10.63.144.0/20" master="10.63.193.176/28" />
-      <NetworkCard cluster="Available – Slot 29" primary="10.61.192.0/20" pods="10.56.0.0/15" services="10.63.160.0/20" master="10.63.193.192/28" />
-      <NetworkCard cluster="Available – Slot 30" primary="10.61.208.0/20" pods="10.58.0.0/15" services="10.63.176.0/20" master="10.63.193.208/28" />
+      <NetworkCard cluster="Available \u2013 Slot 10" primary="10.60.144.0/20" pods="10.18.0.0/15" services="10.62.112.0/20" master="10.63.192.144/28" />
+      <NetworkCard cluster="Available \u2013 Slot 11" primary="10.60.160.0/20" pods="10.20.0.0/15" services="10.62.128.0/20" master="10.63.192.160/28" />
+      <NetworkCard cluster="Available \u2013 Slot 12" primary="10.60.176.0/20" pods="10.22.0.0/15" services="10.62.144.0/20" master="10.63.192.176/28" />
+      <NetworkCard cluster="Available \u2013 Slot 13" primary="10.60.192.0/20" pods="10.24.0.0/15" services="10.62.160.0/20" master="10.63.192.192/28" />
+      <NetworkCard cluster="Available \u2013 Slot 14" primary="10.60.208.0/20" pods="10.26.0.0/15" services="10.62.176.0/20" master="10.63.192.208/28" />
+      <NetworkCard cluster="Available \u2013 Slot 15" primary="10.60.224.0/20" pods="10.28.0.0/15" services="10.62.192.0/20" master="10.63.192.224/28" />
+      <NetworkCard cluster="Available \u2013 Slot 16" primary="10.60.240.0/20" pods="10.30.0.0/15" services="10.62.208.0/20" master="10.63.192.240/28" />
+      <NetworkCard cluster="Available \u2013 Slot 17" primary="10.61.0.0/20" pods="10.32.0.0/15" services="10.62.224.0/20" master="10.63.193.0/28" />
+      <NetworkCard cluster="Available \u2013 Slot 18" primary="10.61.16.0/20" pods="10.34.0.0/15" services="10.62.240.0/20" master="10.63.193.16/28" />
+      <NetworkCard cluster="Available \u2013 Slot 19" primary="10.61.32.0/20" pods="10.36.0.0/15" services="10.63.0.0/20" master="10.63.193.32/28" />
+      <NetworkCard cluster="Available \u2013 Slot 20" primary="10.61.48.0/20" pods="10.38.0.0/15" services="10.63.16.0/20" master="10.63.193.48/28" />
+      <NetworkCard cluster="Available \u2013 Slot 21" primary="10.61.64.0/20" pods="10.40.0.0/15" services="10.63.32.0/20" master="10.63.193.64/28" />
+      <NetworkCard cluster="Available \u2013 Slot 22" primary="10.61.80.0/20" pods="10.42.0.0/15" services="10.63.48.0/20" master="10.63.193.80/28" />
+      <NetworkCard cluster="Available \u2013 Slot 23" primary="10.61.96.0/20" pods="10.44.0.0/15" services="10.63.64.0/20" master="10.63.193.96/28" />
+      <NetworkCard cluster="Available \u2013 Slot 24" primary="10.61.112.0/20" pods="10.46.0.0/15" services="10.63.80.0/20" master="10.63.193.112/28" />
+      <NetworkCard cluster="Available \u2013 Slot 25" primary="10.61.128.0/20" pods="10.48.0.0/15" services="10.63.96.0/20" master="10.63.193.128/28" />
+      <NetworkCard cluster="Available \u2013 Slot 26" primary="10.61.144.0/20" pods="10.50.0.0/15" services="10.63.112.0/20" master="10.63.193.144/28" />
+      <NetworkCard cluster="Available \u2013 Slot 27" primary="10.61.160.0/20" pods="10.52.0.0/15" services="10.63.128.0/20" master="10.63.193.160/28" />
+      <NetworkCard cluster="Available \u2013 Slot 28" primary="10.61.176.0/20" pods="10.54.0.0/15" services="10.63.144.0/20" master="10.63.193.176/28" />
+      <NetworkCard cluster="Available \u2013 Slot 29" primary="10.61.192.0/20" pods="10.56.0.0/15" services="10.63.160.0/20" master="10.63.193.192/28" />
+      <NetworkCard cluster="Available \u2013 Slot 30" primary="10.61.208.0/20" pods="10.58.0.0/15" services="10.63.176.0/20" master="10.63.193.208/28" />
     </CardGrid>
 
   </TabItem>
@@ -102,12 +102,12 @@ VPC: standard-shared
     Unused address space within `10.0.0.0/10` after all 30 cluster slots are allocated.
 
     <CardGrid>
-      <Card item={{ icon: '⬜', title: '10.63.193.224/27', note: '10.63.193.224 – 10.63.193.255' }} />
-      <Card item={{ icon: '⬜', title: '10.63.194.0/23', note: '10.63.194.0 – 10.63.195.255' }} />
-      <Card item={{ icon: '⬜', title: '10.63.196.0/22', note: '10.63.196.0 – 10.63.199.255' }} />
-      <Card item={{ icon: '⬜', title: '10.63.200.0/21', note: '10.63.200.0 – 10.63.207.255' }} />
-      <Card item={{ icon: '⬜', title: '10.63.208.0/20', note: '10.63.208.0 – 10.63.223.255' }} />
-      <Card item={{ icon: '⬜', title: '10.63.224.0/19', note: '10.63.224.0 – 10.63.255.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.193.224/27', note: '10.63.193.224 \u2013 10.63.193.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.194.0/23', note: '10.63.194.0 \u2013 10.63.195.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.196.0/22', note: '10.63.196.0 \u2013 10.63.199.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.200.0/21', note: '10.63.200.0 \u2013 10.63.207.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.208.0/20', note: '10.63.208.0 \u2013 10.63.223.255' }} />
+      <Card item={{ icon: '⬜', title: '10.63.224.0/19', note: '10.63.224.0 \u2013 10.63.255.255' }} />
     </CardGrid>
 
   </TabItem>

--- a/docs/stream-aligned-teams/foo/index.md
+++ b/docs/stream-aligned-teams/foo/index.md
@@ -1,0 +1,8 @@
+---
+sidebar_label: Foo
+description: A stream-aligned team delivering value directly to end users as part of the osinfra.io platform.
+---
+
+# Foo
+
+A stream-aligned team delivering value directly to end users as part of the osinfra.io platform.

--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -55,4 +55,5 @@ Logos runs OpenTofu on merge — the GCP folder hierarchy, identity groups, and 
 
 <CardGrid>
   <Card item={{ icon: '🧭', title: 'Ethos', note: 'The lived moral character that customers experience — the trustworthiness, transparency, and integrity through which the business earns and keeps their confidence.', link: '/stream-aligned-teams/ethos', linkText: 'Learn more →' }} />
+  <Card item={{ icon: '🌊', title: 'Foo', note: 'A stream-aligned team delivering value directly to end users as part of the osinfra.io platform.', link: '/stream-aligned-teams/foo', linkText: 'Learn more →' }} />
 </CardGrid>

--- a/sidebars.js
+++ b/sidebars.js
@@ -99,6 +99,12 @@ const sidebars = {
           link: { type: 'doc', id: 'stream-aligned-teams/ethos/index' },
           items: [],
         },
+        {
+          type: 'category',
+          label: 'Foo',
+          link: { type: 'doc', id: 'stream-aligned-teams/foo/index' },
+          items: [],
+        },
         // endregion: stream-aligned-teams
       ],
     },


### PR DESCRIPTION
## Summary

Adds the Foo stream-aligned team to the docs site and claims CIDR slot 09 for the `st-foo-us-east4-b` GKE cluster.

## Changes

- `docs/stream-aligned-teams/index.md` — adds Foo card to the team grid
- `docs/stream-aligned-teams/foo/index.md` — new team index page
- `sidebars.js` — adds Foo to the Stream-Aligned Teams sidebar
- `docs/platform-teams/corpus/networking.md` — claims slot 09 (`10.60.128.0/20`) for `st-foo-us-east4-b`; Active Clusters 8→9, Available Slots 22→21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation page for Foo stream-aligned team with role description.
  * Updated networking documentation to reflect new cluster configuration and resource allocation.
  * Extended sidebar navigation structure to provide access to new team documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->