### PR TITLE
Update Nomos Agent reference in networking docs

### DIFF
--- a/docs/platform-grouping/corpus/networking.md
+++ b/docs/platform-grouping/corpus/networking.md
@@ -133,9 +133,9 @@ This block is available for future use.
 
 ## Consumer Contract
 
-A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. Each environment has its own isolated VPC, so the plan supports up to 30 clusters per environment in the active `/10` block, expandable to 120 per environment across all four `/10` blocks. When all 30 slots in the active block are claimed, the Logos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
+A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. Each environment has its own isolated VPC, so the plan supports up to 30 clusters per environment in the active `/10` block, expandable to 120 per environment across all four `/10` blocks. When all 30 slots in the active block are claimed, the Nomos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
 
-To provision a new cluster, use the [Logos Agent](https://github.com/osinfra-io/pt-logos/blob/main/.github/agents/logos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
+To provision a new cluster, use the [Nomos Agent](https://github.com/osinfra-io/pt-techne-agents/blob/main/.github/agents/nomos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
 
 ## Components
 

--- a/docs/platform-grouping/corpus/networking.md
+++ b/docs/platform-grouping/corpus/networking.md
@@ -135,7 +135,7 @@ This block is available for future use.
 
 A new GKE cluster is always guaranteed a pre-allocated CIDR slot — no IP conflict is possible because every range is defined in [pt-logos](https://github.com/osinfra-io/pt-logos) before any cluster is created. Each environment has its own isolated VPC, so the plan supports up to 30 clusters per environment in the active `/10` block, expandable to 120 per environment across all four `/10` blocks. When all 30 slots in the active block are claimed, the Nomos Agent's IPAM sequences must be extended to cover the next `/10` block before any additional clusters can be provisioned.
 
-To provision a new cluster, use the [Nomos Agent](https://github.com/osinfra-io/pt-techne-agents/blob/main/.github/agents/nomos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
+To provision a new cluster, use the [Nomos Agent](https://github.com/osinfra-io/pt-techne-agents/blob/main/.github/agents/techne-nomos.agent.md) in [pt-logos](https://github.com/osinfra-io/pt-logos). The agent reads all existing CIDR allocations from `teams/*.tfvars`, assigns the next available slot automatically, and opens the necessary pull requests — no manual CIDR selection required.
 
 ## Components
 

--- a/docs/platform-grouping/pneuma/cluster-management.md
+++ b/docs/platform-grouping/pneuma/cluster-management.md
@@ -21,7 +21,7 @@ sequenceDiagram
     participant Corpus as pt-corpus
     participant Pneuma as pt-pneuma
 
-    Team->>Logos: Logos Agent PR merges
+    Team->>Logos: Nomos Agent PR merges
     Logos->>Logos: OpenTofu: GCP folders, identity groups, GitHub structure
 
     Note over Corpus,Pneuma: Platform engineer triggers workflow_dispatch (or next merge to main)

--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -40,10 +40,11 @@ The GitHub MCP server must be configured with a **fine-grained Personal Access T
 | Permission | Access |
 |---|---|
 | Contents | Read and write |
+| Issues | Read and write |
 | Pull requests | Read and write |
 | Workflows | Read and write |
 
-Fine-grained PATs must be created through the GitHub web UI at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new).
+Fine-grained PATs must be created through the GitHub web UI at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new). Set the resource owner to the **`osinfra-io` organization** (not individual repositories) so the token can operate across all repos the agent needs to reach.
 
 :::
 

--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -13,13 +13,13 @@ Stream-aligned teams work directly on the flow of change to deliver value to end
 
 ## Onboarding
 
-The fastest way to get your team onto the platform is the **Nomos Agent** — a GitHub Copilot coding agent that handles the full onboarding conversation and opens a pull request with every change. No local setup, no YAML to write by hand.
+The fastest way to get your team onto the platform is the **Nomos Agent** — your self-serve interface to the osinfra.io platform. Tell it what you need and it handles the rest, opening a pull request with every change. No local setup, no YAML to write by hand.
 
 <AgentDemo />
 
 ### The Nomos Agent
 
-The Nomos Agent manages everything a stream-aligned team needs on the platform: GCP folder hierarchy, identity groups, GitHub teams, Datadog team, repositories, environments, and feature flags. It reads the current state from `pt-logos` and opens a reviewed pull request for every change — nothing is applied directly.
+The Nomos Agent is the platform's self-serve interface for all teams. Describe what your team needs — identity structure, repositories, infrastructure, or configuration — and Nomos handles the platform internals, opening a reviewed pull request for every change. Nothing is applied directly.
 
 ### How to invoke it
 

--- a/docs/stream-aligned-teams/index.md
+++ b/docs/stream-aligned-teams/index.md
@@ -13,21 +13,21 @@ Stream-aligned teams work directly on the flow of change to deliver value to end
 
 ## Onboarding
 
-The fastest way to get your team onto the platform is the **Logos Agent** — a GitHub Copilot coding agent that handles the full onboarding conversation and opens a pull request with every change. No local setup, no YAML to write by hand.
+The fastest way to get your team onto the platform is the **Nomos Agent** — a GitHub Copilot coding agent that handles the full onboarding conversation and opens a pull request with every change. No local setup, no YAML to write by hand.
 
 <AgentDemo />
 
-### The Logos Agent
+### The Nomos Agent
 
-The Logos Agent manages everything a stream-aligned team needs on the platform: GCP folder hierarchy, identity groups, GitHub teams, Datadog team, repositories, environments, and feature flags. It reads the current state from `pt-logos` and opens a reviewed pull request for every change — nothing is applied directly.
+The Nomos Agent manages everything a stream-aligned team needs on the platform: GCP folder hierarchy, identity groups, GitHub teams, Datadog team, repositories, environments, and feature flags. It reads the current state from `pt-logos` and opens a reviewed pull request for every change — nothing is applied directly.
 
 ### How to invoke it
 
-Clone the repo and run the Copilot CLI from within it — then type `/agent` and select **Logos Agent** from the menu:
+Clone the repo and run the Copilot CLI from within it — then type `/agent` and select **Nomos Agent** from the menu:
 
 ```none
-git clone https://github.com/osinfra-io/pt-logos
-cd pt-logos
+git clone https://github.com/osinfra-io/pt-techne-agents
+cd pt-techne-agents
 gh copilot
 ```
 

--- a/src/components/AgentDemo/index.jsx
+++ b/src/components/AgentDemo/index.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-const defaultTitle = 'GitHub Copilot — Logos Agent';
+const defaultTitle = 'GitHub Copilot — Nomos Agent';
 
 const defaultMessages = [
   {
     role: 'user',
-    text: '/agent → Logos Agent',
+    text: '/agent → Nomos Agent',
   },
   {
     role: 'agent',
     content: (
       <>
-        <p>👋 Hi! I'm the Logos Agent. I help manage everything on the osinfra.io platform — teams, members, repositories, environments, and more.</p>
+        <p>👋 Hi! I'm the Nomos Agent — your self-serve interface to the osinfra.io platform. Just tell me what your team needs.</p>
         <p>Give me just a moment while I look you up…</p>
         <p className={styles.meta}>✓ Identity validated · joe@osinfra.io</p>
         <p>It looks like you're not part of any team yet — welcome! Would you like to <strong>join an existing team</strong> or <strong>onboard a new team</strong> from scratch?</p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -102,7 +102,7 @@ function GettingStarted() {
             Your team, on the platform in minutes
           </Heading>
           <p className={styles.gettingStartedBody}>
-            The <strong>Logos Agent</strong> handles the full onboarding conversation and opens a pull request with every change — GCP folder hierarchy, identity groups, GitHub teams, Datadog team, and repositories. No YAML to write by hand, no support ticket to file.
+            The <strong>Nomos Agent</strong> handles the full onboarding conversation and opens a pull request with every change — GCP folder hierarchy, identity groups, GitHub teams, Datadog team, and repositories. No YAML to write by hand, no support ticket to file.
           </p>
           <Link
             to="/stream-aligned-teams#onboarding"


### PR DESCRIPTION
Updates the Logos Agent reference in the networking documentation to point to the [Nomos Agent](https://github.com/osinfra-io/pt-techne-agents/blob/main/.github/agents/nomos.agent.md) at its new home in `pt-techne-agents`.

## Changes

- `docs/platform-grouping/corpus/networking.md` — updated GitHub URL and renamed "Logos Agent" → "Nomos Agent"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding documentation and setup instructions with revised agent configuration.
  * Expanded GitHub MCP token requirements to include Issues: Read and write permissions with org-level resource owner scope.
  * Refreshed agent demo interface and getting-started content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->