### PR TITLE
Update techne docs for tofu-scan pre-commit hook

### DIFF
--- a/docs/platform-grouping/techne/developer-experience.md
+++ b/docs/platform-grouping/techne/developer-experience.md
@@ -7,7 +7,7 @@ sidebar_label: Developer Experience
 Standardized tooling and environments that make developing and iterating on platform infrastructure consistent and reproducible.
 
 - **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)**: A GitHub Codespace pre-configured with OpenTofu, pre-commit, and all platform tooling — ready to use without local setup
-- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Custom pre-commit hooks written in Go that enforce IaC formatting (`tofu fmt`), configuration validation (`tofu validate`), and automated testing (`tofu test`) before every commit
+- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Custom pre-commit hooks written in Go that enforce IaC formatting (`tofu fmt`), configuration validation (`tofu validate`), automated testing (`tofu test`), and CIS benchmark scanning (`tofu scan`) before every commit
 - **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)**: Local development environment setup for engineers who prefer working outside of Codespaces
 
 :::tip Architecture Decision Records
@@ -24,11 +24,12 @@ A GitHub Codespace pre-configured with OpenTofu, pre-commit, gcloud, kubectl, an
 
 ### Pre-commit Toolchain
 
-The primary resource is `pre-commit-config` — a `.pre-commit-config.yaml` file pinned to specific hook versions, enforcing `tofu fmt`, `tofu validate`, `tofu test`, YAML lint, and trailing whitespace. Identical in local and CI environments.
+The primary resource is `pre-commit-config` — a `.pre-commit-config.yaml` file pinned to specific hook versions, enforcing `tofu fmt`, `tofu validate`, `tofu test`, `tofu scan`, YAML lint, and trailing whitespace. Identical in local and CI environments.
 
 | Component | Description |
 |---|---|
-| `pre-commit-hook` | A custom hook (written in Go) in `pt-techne-pre-commit-hooks` implementing platform-specific IaC checks beyond what stock hooks provide |
+| `pre-commit-hook` | Custom hooks (written in Go) in `pt-techne-pre-commit-hooks` implementing platform-specific IaC checks beyond what stock hooks provide |
+| `tofuscan` | A CIS benchmark scanner that checks OpenTofu files against CIS Google Cloud Platform Foundation Benchmark v3.0.0 and CIS GKE Benchmark v1.6.1 using OPA/Rego — supports inline skip comments and a `--warn-only` flag for non-blocking scans |
 
 ### Local Development Setup
 
@@ -106,7 +107,7 @@ When the Codespace starts, all `pt-*` repositories in the `osinfra-io` organizat
 
 `pre-commit run -a` must pass before any commit.
 
-CI enforces the core OpenTofu checks (`tofu fmt`, `tofu validate`, `tofu test`) directly — it does not run the full pre-commit suite. YAML lint, trailing whitespace, and custom hooks are local-only gates.
+CI enforces the core OpenTofu checks (`tofu fmt`, `tofu validate`, `tofu test`) directly — it does not run the full pre-commit suite. YAML lint, trailing whitespace, `tofu scan`, and custom hooks are local-only gates.
 
 ## Architecture Decision Records
 

--- a/docs/platform-grouping/techne/developer-experience.md
+++ b/docs/platform-grouping/techne/developer-experience.md
@@ -24,7 +24,7 @@ A GitHub Codespace pre-configured with OpenTofu, pre-commit, gcloud, kubectl, an
 
 ### Pre-commit Toolchain
 
-The primary resource is `pre-commit-config` — a `.pre-commit-config.yaml` file pinned to specific hook versions, enforcing `tofu fmt`, `tofu validate`, `tofu test`, `tofu scan`, YAML lint, and trailing whitespace. Identical in local and CI environments.
+The primary resource is `pre-commit-config` — a `.pre-commit-config.yaml` file pinned to specific hook versions, enforcing `tofu fmt`, `tofu validate`, `tofu test`, `tofu scan`, YAML lint, and trailing whitespace locally before every commit. CI runs the core OpenTofu checks (`tofu fmt`, `tofu validate`, `tofu test`) directly rather than executing the full pre-commit suite.
 
 | Component | Description |
 |---|---|

--- a/docs/platform-grouping/techne/developer-experience.md
+++ b/docs/platform-grouping/techne/developer-experience.md
@@ -28,8 +28,10 @@ The primary resource is `pre-commit-config` — a `.pre-commit-config.yaml` file
 
 | Component | Description |
 |---|---|
-| `pre-commit-hook` | Custom hooks (written in Go) in `pt-techne-pre-commit-hooks` implementing platform-specific IaC checks beyond what stock hooks provide |
-| `tofuscan` | A CIS benchmark scanner that checks OpenTofu files against CIS Google Cloud Platform Foundation Benchmark v3.0.0 and CIS GKE Benchmark v1.6.1 using OPA/Rego — supports inline skip comments and a `--warn-only` flag for non-blocking scans |
+| `tofu-fmt` | Rewrites OpenTofu (`.tf`, `.tofu`, `.tfvars`, `.tftest.hcl`) files to canonical format — skips `.terraform/` directories |
+| `tofu-validate` | Checks configuration for syntax errors and internal consistency without accessing remote services |
+| `tofu-test` | Executes automated tests defined in `.tftest.hcl` files — runs in the root directory only, skips if no test files are found |
+| `tofu-scan` | Checks OpenTofu files against CIS Google Cloud Platform Foundation Benchmark v3.0.0 and CIS GKE Benchmark v1.6.1 using OPA/Rego — supports inline skip comments and a `--warn-only` flag for non-blocking scans |
 
 ### Local Development Setup
 

--- a/docs/platform-grouping/techne/index.md
+++ b/docs/platform-grouping/techne/index.md
@@ -19,7 +19,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 - **[pt-techne-opentofu-workflows](https://github.com/osinfra-io/pt-techne-opentofu-workflows)**: Reusable GitHub Actions called workflows for OpenTofu deployments — see [Deployment Automation](./deployment-automation.md)
 - **[pt-techne-misc-workflows](https://github.com/osinfra-io/pt-techne-misc-workflows)**: Reusable GitHub Actions called workflows for common repository tasks
-- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Pre-commit hooks for IaC validation and formatting — see [Developer Experience](./developer-experience.md)
+- **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Pre-commit hooks for IaC validation, formatting, and CIS benchmark scanning — see [Developer Experience](./developer-experience.md)
 - **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)**: GitHub Codespace configuration for standardized OpenTofu development environments
 - **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)**: Local development setup and tooling configuration
 


### PR DESCRIPTION
Updates the Techne index and Developer Experience pages to reflect the new `tofu-scan` pre-commit hook and `--warn-only` flag added in [pt-techne-pre-commit-hooks#32](https://github.com/osinfra-io/pt-techne-pre-commit-hooks/pull/32) and [pt-techne-pre-commit-hooks#34](https://github.com/osinfra-io/pt-techne-pre-commit-hooks/pull/34).\n\n### Changes\n\n- Add `tofu scan` and CIS benchmark scanning to repo descriptions in both `index.md` and `developer-experience.md`\n- Add `tofuscan` component row with CIS benchmark versions, OPA/Rego, skip comments, and `--warn-only` flag\n- Add `tofu scan` to the pre-commit toolchain list\n- Clarify `tofu scan` as a local-only gate in the Core Invariant section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced developer tooling documentation to clarify boundaries between local enforcement and continuous integration enforcement.
  * Added details about CIS benchmark scanning capabilities integrated into the pre-commit toolchain.
  * Expanded repository documentation with comprehensive information on infrastructure validation and security scanning features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-ekklesia-docs/pull/64)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->