### PR TITLE
Add AI Tooling page for pt-techne-mcp-server and pt-techne-agents

### DIFF
--- a/docs/platform-grouping/techne/ai-tooling.md
+++ b/docs/platform-grouping/techne/ai-tooling.md
@@ -40,11 +40,9 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 |---|---|
 | `techne-nomos` | The self-serve interface to the osinfra.io platform — onboard teams, manage members and repositories, request infrastructure, and configure platform resources through a single conversation |
 
-## Core Invariants
+### Core Invariant
 
-- Agents never hand-write HCL — all `teams/*.tfvars` writes go through `render_team_tfvars` in the MCP server.
-- All write tools are idempotent — identical input and repo state returns `action: "noop"`.
-- `schema/team.schema.json` in `pt-techne-mcp-server` is the source of truth for validation and rendering; the [Logos team topology page](/platform-grouping/logos/team-topology) is the documentation home for the schema.
+Agents must never hand-write HCL: all `teams/*.tfvars` writes must go through the `render_team_tfvars` path in the MCP server, all write tools must be idempotent, with `schema/team.schema.json` as the single source of truth for validation and rendering.
 
 ## Architecture Decision Records
 

--- a/docs/platform-grouping/techne/ai-tooling.md
+++ b/docs/platform-grouping/techne/ai-tooling.md
@@ -1,0 +1,82 @@
+---
+sidebar_label: AI Tooling
+---
+
+# AI Tooling
+
+MCP server and Copilot agents that expose platform capabilities as AI-native interfaces — typed, tested tools for agents and a self-serve conversational interface for teams.
+
+- **[pt-techne-mcp-server](https://github.com/osinfra-io/pt-techne-mcp-server)**: Model Context Protocol server providing deterministic, typed tools so platform agents call a tested renderer instead of writing HCL by hand — covers team spec validation, tfvars rendering, PR operations, and docs generation
+- **[pt-techne-agents](https://github.com/osinfra-io/pt-techne-agents)**: GitHub Copilot agent catalog — each agent is a self-serve interface to a platform capability that handles the platform internals and opens a pull request with every change
+
+:::tip Architecture Decision Records
+
+This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
+
+:::
+
+## Components
+
+### MCP Server Tools
+
+| Tool | Description |
+|---|---|
+| `validate_team_spec` | Validates a team spec object against the JSON schema — returns structured errors with path and message |
+| `render_team_tfvars` | Renders a canonical `pt-logos` `.tfvars` file from a validated spec — enforces alphabetical ordering, indentation, and field placement |
+| `open_team_pr` | Validates, renders, and opens or updates a PR on `pt-logos` in one idempotent call |
+| `list_teams` | Lists all teams from `pt-logos@main` — team key, display name, type, member count, repo count, and env count |
+| `get_team` | Returns a team's spec and existing docs pages from `pt-ekklesia-docs@main` |
+| `lookup_user` | Resolves a GitHub username or email to every team membership across all team files |
+| `find_repo` | Finds which team owns a repository by name |
+| `render_corpus_helpers` | Returns updated `pt-corpus/helpers.tofu` bytes with the team's workspace inserted |
+| `render_pneuma_helpers` | Returns updated `pt-pneuma/helpers.tofu` bytes with the team's workspace inserted |
+| `render_team_docs_index` | Renders a `docs/<section>/<team>/index.md` stub for `pt-ekklesia-docs` |
+| `render_sidebar_patch` | Patches `pt-ekklesia-docs/sidebars.js` to register the new team page |
+| `open_team_docs_pr` | Lands the docs index page and sidebars patch as a PR on `pt-ekklesia-docs` in one idempotent call |
+
+### Copilot Agents
+
+| Agent | Description |
+|---|---|
+| `techne-nomos` | The self-serve interface to the osinfra.io platform — onboard teams, manage members and repositories, request infrastructure, and configure platform resources through a single conversation |
+
+## Core Invariants
+
+- Agents never hand-write HCL — all `teams/*.tfvars` writes go through `render_team_tfvars` in the MCP server.
+- All write tools are idempotent — identical input and repo state returns `action: "noop"`.
+- The MCP server schema (`schema/team.schema.json`) is the single source of truth for team spec fields; `docs/schema.md` is generated from it.
+
+## Architecture Decision Records
+
+### MCP Server as the Agent-Platform Interface
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>May 2026</td><td>Techne</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+Platform agents need to produce valid, canonically formatted HCL to manage team resources. Without a shared interface, each agent would need to understand tfvars structure, field ordering, and validation rules independently — producing subtle differences in output that cause noisy diffs and validation failures. The JSON schema for a team spec is the natural source of truth, but it is not useful to agents directly unless there is a server that validates and renders against it.
+
+#### Decision
+
+Expose platform operations as a typed MCP server (`pt-techne-mcp-server`). Agents call tested renderers and validators; they never hand-write HCL. The schema (`schema/team.schema.json`) is the single source of truth for all team spec fields and validation rules.
+
+Copilot agents in `pt-techne-agents` call the MCP server for all write operations. The agents own the conversational interface; the MCP server owns correctness and formatting.
+
+#### Alternatives Considered
+
+- **Agents write HCL directly** — Rejected. Every agent must independently understand formatting, field ordering, and schema validation. Any model drift in output format causes failures across multiple callers.
+- **Shared prompt library** — Rejected. Prompts are not typed, not testable, and not versioned independently of the agents that consume them. Schema changes require updating every prompt.
+
+#### Consequences
+
+- All write paths go through one tested renderer — formatting and validation is consistent across all agents and callers
+- Schema changes propagate automatically; agents do not need to be updated for new optional fields
+- The MCP server can be tested independently of the agents that consume it
+- Adding a new agent capability requires only new MCP tools, not changes to existing agents

--- a/docs/platform-grouping/techne/ai-tooling.md
+++ b/docs/platform-grouping/techne/ai-tooling.md
@@ -44,7 +44,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 - Agents never hand-write HCL — all `teams/*.tfvars` writes go through `render_team_tfvars` in the MCP server.
 - All write tools are idempotent — identical input and repo state returns `action: "noop"`.
-- The MCP server schema (`schema/team.schema.json`) is the single source of truth for team spec fields; `docs/schema.md` is generated from it.
+- `schema/team.schema.json` in `pt-techne-mcp-server` is the source of truth for validation and rendering; the [Logos team topology page](/platform-grouping/logos/team-topology) is the documentation home for the schema.
 
 ## Architecture Decision Records
 
@@ -77,6 +77,6 @@ Copilot agents in `pt-techne-agents` call the MCP server for all write operation
 #### Consequences
 
 - All write paths go through one tested renderer — formatting and validation is consistent across all agents and callers
-- Schema changes propagate automatically; agents do not need to be updated for new optional fields
-- The MCP server can be tested independently of the agents that consume it
+- The Go binary embeds the schema at build time (`internal/spec/schema_embed.json`); new optional fields are picked up on the next server release
+- The Logos docs `logosTeamSchema.js` is a separate display representation and must be kept in sync with `schema/team.schema.json` manually or via a generator — it is the known maintenance surface
 - Adding a new agent capability requires only new MCP tools, not changes to existing agents

--- a/docs/platform-grouping/techne/index.md
+++ b/docs/platform-grouping/techne/index.md
@@ -22,6 +22,8 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 - **[pt-techne-pre-commit-hooks](https://github.com/osinfra-io/pt-techne-pre-commit-hooks)**: Pre-commit hooks for IaC validation, formatting, and CIS benchmark scanning — see [Developer Experience](./developer-experience.md)
 - **[pt-techne-opentofu-codespace](https://github.com/osinfra-io/pt-techne-opentofu-codespace)**: GitHub Codespace configuration for standardized OpenTofu development environments
 - **[pt-techne-development-setup](https://github.com/osinfra-io/pt-techne-development-setup)**: Local development setup and tooling configuration
+- **[pt-techne-mcp-server](https://github.com/osinfra-io/pt-techne-mcp-server)**: MCP server providing platform context and typed tools to AI assistants — see [AI Tooling](./ai-tooling.md)
+- **[pt-techne-agents](https://github.com/osinfra-io/pt-techne-agents)**: GitHub Copilot agent catalog for self-serve platform operations — see [AI Tooling](./ai-tooling.md)
 
 ### AI Context
 
@@ -35,7 +37,9 @@ Techne is a shared service used by all platform teams — its workflows, hooks, 
 
 | Term | Meaning in this context |
 |---|---|
+| Agent | A GitHub Copilot agent defined in `pt-techne-agents/.github/agents/` that uses platform MCP tools to handle requests and open pull requests |
 | Codespace | A GitHub-hosted development environment defined in `pt-techne-opentofu-codespace` |
+| MCP | Model Context Protocol — a standard for exposing typed, testable tools to AI models |
 | OIDC | OpenID Connect — the token-based authentication protocol that eliminates static credentials from CI |
 | Pre-commit hook | A script in `pt-techne-pre-commit-hooks` that runs automatically before every git commit |
 | Workflow | A GitHub Actions called workflow in `pt-techne-opentofu-workflows` consumed via `workflow_call` |
@@ -48,7 +52,7 @@ Techne's domains are medium and low complexity individually — the craft is in 
 
 | Working Domains | High Intrinsic Domains |
 |---|---|
-| 🟢 2 / 4 | 🟢 0 / 3 |
+| 🟡 3 / 4 | 🟢 0 / 3 |
 
 Cognitive load by domain:
 
@@ -56,8 +60,9 @@ Cognitive load by domain:
 |---|---|---|---|
 | Deployment Automation | 🟡 Medium | Reusable called workflows | GitHub Actions, OIDC patterns |
 | Developer Experience | 🟢 Low | Pre-commit automation | DevX & productivity design |
+| AI Tooling | 🟡 Medium | MCP server abstraction | MCP protocol, schema design, Copilot agent patterns |
 
-**Capacity**: 0 high-complexity domains (Team Topologies guideline: 2–3); team members hold 2 active domains — well within the ~4 working-knowledge limit.
+**Capacity**: 0 high-complexity domains (Team Topologies guideline: 2–3); team members hold 3 active domains — within the ~4 working-knowledge limit.
 
 **Extraneous load is minimized by:**
 
@@ -69,6 +74,7 @@ Cognitive load by domain:
 - GitHub Actions ecosystem: called workflow design, input/output contracts, and backward compatibility
 - CI/CD security patterns: OIDC federation, least-privilege service accounts, and short-lived tokens
 - Developer productivity: understanding what friction platform and stream-aligned engineers actually encounter and systematically removing it
+- AI tooling patterns: MCP protocol design, JSON schema authoring, agent behavioral design, and idempotent write operations
 
 ### Team Capacity
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -82,6 +82,7 @@ const sidebars = {
           items: [
             'platform-grouping/techne/deployment-automation',
             'platform-grouping/techne/developer-experience',
+            'platform-grouping/techne/ai-tooling',
           ],
         },
         // endregion: platform-grouping


### PR DESCRIPTION
## Summary

Adds documentation for the two new Techne repositories that weren't covered in the existing docs.

### Changes

- **New page**: \docs/platform-grouping/techne/ai-tooling.md\
  - MCP server tool reference table (all 12 tools)
  - Copilot agents table (\	echne-nomos\)
  - Core invariants
  - ADR: *MCP Server as the Agent-Platform Interface*

- **\	echne/index.md\** updates:
  - \pt-techne-mcp-server\ and \pt-techne-agents\ added to Repositories list
  - AI Tooling domain added to cognitive load table (3/4 working domains, medium intrinsic)
  - \Agent\ and \MCP\ glossary entries added
  - Germane load list extended with AI tooling patterns

- **\sidebars.js\**: \platform-grouping/techne/ai-tooling\ registered under Techne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added AI Tooling guidance for Techne, describing the MCP server and Copilot agent catalog approach, core invariants, and an architecture decision record.
  * Expanded Techne docs to list new repositories, refine glossary entries (Agent, Codespace, MCP), and adjust team-topology metrics and capacity statements.
  * Updated site navigation to include the new AI Tooling documentation page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-ekklesia-docs/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->