### PR TITLE
Update Techne working domains to 3/4

### DIFF
--- a/docs/platform-grouping/index.md
+++ b/docs/platform-grouping/index.md
@@ -80,7 +80,7 @@ Team Topologies distinguishes three types of cognitive load — **intrinsic** (i
 | Team | Working Domains | High Intrinsic Domains |
 |---|---|---|
 | Ekklesia | 🟢 1 / 4 | 🟢 0 / 3 |
-| Techne | 🟢 2 / 4 | 🟢 0 / 3 |
+| Techne | 🟡 3 / 4 | 🟢 0 / 3 |
 | Arche | 🟢 3 / 4 | 🟢 1 / 3 |
 | Kryptos | 🟢 2 / 4 | 🟡 2 / 3 |
 | Logos | 🟠 4 / 4 | 🟢 0 / 3 |


### PR DESCRIPTION
The main platform grouping index was showing Techne at `🟢 2 / 4` working domains, which was stale. Techne now has three active working domains — Deployment Automation, Developer Experience, and AI Tooling — matching what is documented on the Techne team page.

**Change:** `🟢 2 / 4` → `🟡 3 / 4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Cognitive Load table in Team Topologies documentation. The High Intrinsic Domains value for Techne has been updated from 2 to 3 out of 4.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-ekklesia-docs/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->