### PR TITLE
Use innersource (one word) to align with GitHub's terminology

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,10 +130,10 @@ For staffed teams (dedicated engineer):
 - **Scale signal**: When (or whether) to add headcount
 ```
 
-For inner source teams (no dedicated engineer):
+For innersource teams (no dedicated engineer):
 
 ```md
-- **Headcount**: Inner source — no dedicated engineer
+- **Headcount**: Innersource — no dedicated engineer
 - **Contribution model**: What the contribution model looks like day-to-day
 - **Scale signal**: When (or whether) to change the model
 ```

--- a/docs/platform-grouping/arche/index.md
+++ b/docs/platform-grouping/arche/index.md
@@ -7,7 +7,7 @@ description: The origin and first cause — the primordial source from which all
 
 Arche is the origin and first cause — the primordial source from which all platform foundations draw their initial form and essential nature. Nothing above it exists without it.
 
-Arche operates as an inner-source module library: versioned OpenTofu modules published on GitHub, used by all platform teams as pinned dependencies. All modules build on `pt-arche-core-helpers` for environment detection, standard labels, and team data. See the [module library ADR](#arche-as-an-inner-source-module-library) for the rationale behind this design.
+Arche operates as an innersource module library: versioned OpenTofu modules published on GitHub, used by all platform teams as pinned dependencies. All modules build on `pt-arche-core-helpers` for environment detection, standard labels, and team data. See the [module library ADR](#arche-as-an-innersource-module-library) for the rationale behind this design.
 
 - **[Core Helpers](./core-helpers.md)**: Foundational module providing workspace parsing, standard labels, and Logos integration — consumed by every other `pt-arche-*` module
 - **[Module Development](./module-development.md)**: Copilot agent and skeleton template for creating new `pt-arche-*` modules
@@ -81,13 +81,13 @@ Cognitive load by domain:
 
 ### Team Capacity
 
-- **Headcount**: Inner source — no dedicated engineer
+- **Headcount**: Innersource — no dedicated engineer
 - **Contribution model**: Modules are built when a consuming team needs them and owned by whoever builds them; the child module template and Copilot agent make new module creation frictionless
 - **Scale signal**: Scales with contributor interest — Arche is a shared standard and a set of versioned artifacts, not a team roster
 
 ## Architecture Decision Records
 
-### Arche as an Inner-Source Module Library
+### Arche as an Innersource Module Library
 
 <table>
   <thead>
@@ -106,7 +106,7 @@ The modules also need to evolve independently of the teams that consume them. A 
 
 #### Decision
 
-Organize all reusable OpenTofu modules as an inner-source module library under the `pt-arche-*` namespace. Each module is:
+Organize all reusable OpenTofu modules as an innersource module library under the `pt-arche-*` namespace. Each module is:
 
 - A standalone GitHub repository with its own versioning, tests, and release pipeline
 - Published with semver tags; consumers pin to a full 40-character post-merge commit SHA
@@ -119,7 +119,7 @@ Modules are decomposed into two groups reflecting their infrastructure layer:
 
 This decomposition maps directly to the deployment layers in Corpus (GCP) and Pneuma (Kubernetes), making it clear which modules each team consumes.
 
-A similar inner-source contribution model is used by [Techne](/platform-grouping/techne#techne-as-a-shared-platform-tooling-layer) and [Ekklesia](/platform-grouping/ekklesia#ekklesia-as-an-inner-source-documentation-hub) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
+A similar innersource contribution model is used by [Techne](/platform-grouping/techne#techne-as-a-shared-platform-tooling-layer) and [Ekklesia](/platform-grouping/ekklesia#ekklesia-as-an-innersource-documentation-hub) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
 
 #### Alternatives Considered
 

--- a/docs/platform-grouping/ekklesia/index.md
+++ b/docs/platform-grouping/ekklesia/index.md
@@ -7,7 +7,7 @@ description: The assembly of the called-out — where distinct capabilities are 
 
 Ekklesia is the assembly of the called-out — where distinct capabilities are gathered into a unified body, deliberating and acting in concert toward shared platform purpose. This is that assembly.
 
-Ekklesia operates as the platform's inner-source documentation hub: a single centralized documentation site where any team member can contribute, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [documentation hub ADR](#ekklesia-as-an-inner-source-documentation-hub) for the rationale.
+Ekklesia operates as the platform's innersource documentation hub: a single centralized documentation site where any team member can contribute, rather than maintaining scattered per-repo READMEs or per-team wikis. See the [documentation hub ADR](#ekklesia-as-an-innersource-documentation-hub) for the rationale.
 
 - **[Documentation](./documentation.md)**: Docusaurus site structure, contribution model, and authoring conventions for the platform documentation hub
 
@@ -67,13 +67,13 @@ Cognitive load by domain:
 
 ### Team Capacity
 
-- **Headcount**: Inner source — no dedicated engineer
+- **Headcount**: Innersource — no dedicated engineer
 - **Contribution model**: Every team updates their section as part of their own PRs; Ekklesia owns the site structure and tooling, not the content
 - **Scale signal**: No scaling expected — documentation is a distributed responsibility by design
 
 ## Architecture Decision Records
 
-### Ekklesia as an Inner-Source Documentation Hub
+### Ekklesia as an Innersource Documentation Hub
 
 <table>
   <thead>
@@ -88,7 +88,7 @@ Cognitive load by domain:
 
 Platform knowledge — architecture decisions, module usage, deployment patterns, operational guides — is spread across multiple teams and repositories. Without a shared home, documentation lives in README files that are hard to navigate, per-team wikis that fall out of sync, or not at all. Engineers must hunt across repositories to understand how the platform fits together.
 
-This follows a similar inner-source contribution model to [Arche](/platform-grouping/arche#arche-as-an-inner-source-module-library) and [Techne](/platform-grouping/techne#techne-as-a-shared-platform-tooling-layer) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions workflows and tooling; Ekklesia shares documentation.
+This follows a similar innersource contribution model to [Arche](/platform-grouping/arche#arche-as-an-innersource-module-library) and [Techne](/platform-grouping/techne#techne-as-a-shared-platform-tooling-layer) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions workflows and tooling; Ekklesia shares documentation.
 
 #### Decision
 

--- a/docs/platform-grouping/index.md
+++ b/docs/platform-grouping/index.md
@@ -118,21 +118,21 @@ Each staffed team starts with one platform engineer who owns the team's context 
 | Corpus | 1 | Owns GCP projects, shared VPC, state buckets, and workload identity |
 | Pneuma | 1 | Owns GKE clusters, service mesh, policy enforcement, and cluster add-ons — currently flagged 🔴 over limit, candidate for a second engineer |
 | Kryptos | 1 | Owns secrets infrastructure, PKI, and cryptographic controls |
-| Arche | — | Inner source — no dedicated engineer |
-| Ekklesia | — | Inner source — no dedicated engineer |
-| Techne | — | Inner source — no dedicated engineer |
+| Arche | — | Innersource — no dedicated engineer |
+| Ekklesia | — | Innersource — no dedicated engineer |
+| Techne | — | Innersource — no dedicated engineer |
 
 **Total: 4–5 engineers + 1 Platform Lead** _(minimum staffing — scale per cognitive load analysis)_
 
-#### Inner Source Model
+#### Innersource Model
 
-Arche, Ekklesia, and Techne operate without dedicated engineers. Instead, they run as **inner source** repositories — open for contribution from any engineer on the platform or from stream-aligned teams.
+Arche, Ekklesia, and Techne operate without dedicated engineers. Instead, they run as **innersource** repositories — open for contribution from any engineer on the platform or from stream-aligned teams.
 
 How it works:
 
-- Any engineer may open a pull request to an inner source repo
+- Any engineer may open a pull request to an innersource repo
 - Platform engineers from staffed teams (Logos, Corpus, Pneuma, Kryptos) serve as code owners and reviewers
 - The Platform Lead has final approval authority on structural or architectural changes
 - Stream-aligned teams can unblock themselves by contributing fixes or enhancements directly, rather than filing tickets and waiting
 
-This model distributes platform knowledge across the organization, reduces bottlenecks on the staffed teams, and ensures inner source repos evolve with the needs of their consumers rather than on a centralized backlog.
+This model distributes platform knowledge across the organization, reduces bottlenecks on the staffed teams, and ensures innersource repos evolve with the needs of their consumers rather than on a centralized backlog.

--- a/docs/platform-grouping/techne/index.md
+++ b/docs/platform-grouping/techne/index.md
@@ -78,7 +78,7 @@ Cognitive load by domain:
 
 ### Team Capacity
 
-- **Headcount**: Inner source — no dedicated engineer
+- **Headcount**: Innersource — no dedicated engineer
 - **Contribution model**: Any team can contribute improvements; the Platform Lead holds final approval on interface changes due to blast radius across all consumers
 - **Scale signal**: Stable once built — the platform lead or a senior engineer handles occasional updates
 
@@ -99,7 +99,7 @@ Cognitive load by domain:
 
 Every platform repository needs consistent OpenTofu deployment pipelines (OIDC auth, KMS-encrypted state, job summaries) and pre-commit validation hooks. All repositories — platform and stream-aligned — benefit from a standardized developer environment and shared toolchain. Without a shared approach, each repository would implement these independently, leading to drift and duplicated maintenance.
 
-This follows a similar inner-source contribution model to [Arche](/platform-grouping/arche#arche-as-an-inner-source-module-library) and [Ekklesia](/platform-grouping/ekklesia#ekklesia-as-an-inner-source-documentation-hub) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
+This follows a similar innersource contribution model to [Arche](/platform-grouping/arche#arche-as-an-innersource-module-library) and [Ekklesia](/platform-grouping/ekklesia#ekklesia-as-an-innersource-documentation-hub) — the difference is artifact type. Arche shares OpenTofu modules; Techne shares GitHub Actions called workflows, pre-commit hooks, and Codespace configuration; Ekklesia shares documentation.
 
 #### Decision
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -27,9 +27,9 @@ const features = [
     icon: '🤖',
   },
   {
-    title: 'Inner source, not a bottleneck',
+    title: 'Innersource, not a bottleneck',
     description:
-      'Arche, Ekklesia, and Techne run as inner-source repositories — any engineer can open a pull request, and platform engineers from staffed teams review. Stream-aligned teams unblock themselves by contributing fixes and new capabilities directly to the platform.',
+      'Arche, Ekklesia, and Techne run as innersource repositories — any engineer can open a pull request, and platform engineers from staffed teams review. Stream-aligned teams unblock themselves by contributing fixes and new capabilities directly to the platform.',
     icon: '🤝',
   },
 ];


### PR DESCRIPTION
Replaces all instances of `inner source` (spaced) and `inner-source` (hyphenated) with `innersource`, consistent with https://github.com/resources/articles/innersource.

Also updates Docusaurus anchor links that referenced the renamed ADR headings in `arche/index.md` and `ekklesia/index.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from "inner source" and related variations to "innersource" across platform grouping documentation and homepage content.

* **Style**
  * Standardized capitalization and hyphenation conventions in documentation and configuration files for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-ekklesia-docs/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->