### PR TITLE
Document the Copilot CLI plugins and marketplace

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -186,10 +186,9 @@ Each ADR follows this structure:
 
 <What forced this decision and why it was non-trivial.>
 
-#### Decisions
+#### Decision
 
-1. **<Decision>.** <Rationale.>
-2. **<Decision>.** <Rationale.>
+<The decision and its rationale.>
 
 #### Alternatives Considered
 
@@ -198,10 +197,8 @@ Each ADR follows this structure:
 #### Consequences
 
 - <Bullet list of outcomes, constraints, or follow-on requirements.>
-
-#### Links
-
-- [<Link text>](<url>)
 ```
+
+The `#### Links` section is optional — include a final bulleted list of external references only when the ADR cites them.
 
 See `docs/platform-grouping/corpus/networking.md` for a complete example.

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -65,9 +65,9 @@ Fill in the form, hit **Copy**, then paste the result into the Nomos Agent. The 
   <div style={invokeCard}>
     <span style={iconStyle}>💻</span>
     <p style={cardTitle}>Copilot CLI</p>
-    <p style={{...cardBody, marginBottom: '0.75rem'}}>From a terminal, clone the agents repo and run the Copilot CLI:</p>
-    <pre style={{fontSize: '0.8rem', margin: 0}}>{'git clone https://github.com/osinfra-io/pt-techne-agents\ncd pt-techne-agents\ngh copilot'}</pre>
-    <p style={{...cardBody, marginTop: '0.5rem'}}>Type <code>/agent</code>, select <strong>Nomos Agent</strong>, and paste your prompt.</p>
+    <p style={{...cardBody, marginBottom: '0.75rem'}}>Install the onboarding plugin once, then run the Copilot CLI from any directory:</p>
+    <pre style={{fontSize: '0.8rem', margin: 0}}>{'copilot plugin marketplace add osinfra-io/pt-ai-plugins\ncopilot plugin install techne-onboarding@osinfra-io\ncopilot'}</pre>
+    <p style={{...cardBody, marginTop: '0.5rem'}}>Type <code>/agent</code>, select <strong>Nomos Agent</strong>, and paste your prompt. Installing the plugin also registers the <code>pt-techne-mcp-server</code> tools automatically.</p>
   </div>
   <div style={invokeCard}>
     <span style={iconStyle}>🌐</span>

--- a/docs/platform-grouping/corpus/networking.md
+++ b/docs/platform-grouping/corpus/networking.md
@@ -171,7 +171,7 @@ Each cluster is a regional cluster with a single zonal node pool (e.g., `pt-pneu
 
 The guiding principle throughout: **use GKE defaults unless there is a clear reason not to.**
 
-#### Decisions
+#### Decision
 
 1. **Carve `10.0.0.0/8` into four `/10` blocks.** Each `/10` is large enough for 30 clusters. Four blocks give the platform room to grow across independent address spaces without redesign.
 

--- a/docs/platform-grouping/pneuma/cluster-management.md
+++ b/docs/platform-grouping/pneuma/cluster-management.md
@@ -76,7 +76,7 @@ Kubernetes workload environments require more than just a cluster — they need 
 
 The platform also needs a clear scaling model for clusters. Sizing a single large cluster per environment requires predicting peak load. Cluster failure affects all tenants. Regional failure affects all zones at once.
 
-#### Decisions
+#### Decision
 
 1. **Regional clusters with zone-scoped node pools.** Each cluster has a regional control plane (highly available across three zones) but a single-zone node pool — one cluster per zone (e.g., `pt-pneuma-us-east1-b`, `pt-pneuma-us-east4-a`). Keeping node pools zone-local ensures Istio's locality-aware load balancing routes traffic within the zone by default, preventing cross-zone hot spots in the mesh. Clusters scale by adding zones, not by growing individual cluster size. Each cluster is independently managed, independently upgradeable, and independently recoverable.
 

--- a/docs/platform-grouping/pneuma/index.md
+++ b/docs/platform-grouping/pneuma/index.md
@@ -106,7 +106,7 @@ Pneuma operates 5 working domains against the Team Topologies recommended limit 
 
 The five domains — Cluster Management, Service Mesh, Certificate Management, Policy Enforcement, and Observability — cannot be separated without creating artificial coupling problems. cert-manager CRDs must exist before Istio certificate resources; OPA Gatekeeper runs against all workloads on the cluster. Splitting these concerns across teams would require tight coordination at every upgrade cycle and introduce more extraneous load than the split would remove.
 
-#### Decisions
+#### Decision
 
 1. **Accept the 🔴 overload state as a managed risk.** The five domains are operationally inseparable at the cluster layer. This is a structural reality of the platform, not a resourcing failure. The risk is acknowledged, documented, and mitigated — not ignored.
 

--- a/docs/platform-grouping/techne/ai-tooling.md
+++ b/docs/platform-grouping/techne/ai-tooling.md
@@ -8,6 +8,7 @@ MCP server and Copilot agents that expose platform capabilities as AI-native int
 
 - **[pt-techne-mcp-server](https://github.com/osinfra-io/pt-techne-mcp-server)**: Model Context Protocol server providing deterministic, typed tools so platform agents call a tested renderer instead of writing HCL by hand — covers team spec validation, tfvars rendering, PR operations, and docs generation
 - **[pt-techne-agents](https://github.com/osinfra-io/pt-techne-agents)**: GitHub Copilot agent catalog — each agent is a self-serve interface to a platform capability that handles the platform internals and opens a pull request with every change
+- **[pt-ai-plugins](https://github.com/osinfra-io/pt-ai-plugins)**: the osinfra-io GitHub Copilot CLI plugin marketplace — packages cross-cutting skills and federates team-owned agents and MCP servers (such as the Nomos onboarding plugin) as installable, versioned plugins
 
 :::tip Architecture Decision Records
 
@@ -44,6 +45,24 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 Agents must never hand-write HCL: all `teams/*.tfvars` writes must go through the `render_team_tfvars` path in the MCP server, all write tools must be idempotent, with `schema/team.schema.json` as the single source of truth for validation and rendering.
 
+## Plugins and marketplace
+
+The [`pt-ai-plugins`](https://github.com/osinfra-io/pt-ai-plugins) repository is the osinfra-io GitHub Copilot CLI plugin **marketplace** (registry `osinfra-io`). It distributes installable **capabilities** — skills, agents, and MCP servers — that work from any directory, unlike repo-scoped customizations that only load when Copilot runs inside their home repo.
+
+| Plugin | Bundles | Source |
+|---|---|---|
+| `platform-conventions` | Cross-cutting platform skills (for example `create-pull-request`) | `pt-ai-plugins` |
+| `techne-onboarding` | The `techne-nomos` agent and the `pt-techne-mcp-server` MCP tools | federated from `pt-techne-agents` |
+
+The `techne-onboarding` plugin is **federated**: its manifest lives in `pt-techne-agents` and the marketplace references the repository directly, so the agent stays canonical there and its Promptfoo evaluations keep testing the real file. Its `.mcp.json` pins the server image to a release tag rather than `:latest`. Install both halves at once:
+
+```bash
+copilot plugin marketplace add osinfra-io/pt-ai-plugins
+copilot plugin install techne-onboarding@osinfra-io
+```
+
+Plugins **complement**, and do not replace, custom instructions: `plugin.json` has no field for `copilot-instructions.md` or `*.instructions.md`, which continue to load via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` and per-repo files.
+
 ## Architecture Decision Records
 
 ### MCP Server as the Agent-Platform Interface
@@ -78,3 +97,35 @@ Copilot agents in `pt-techne-agents` call the MCP server for all write operation
 - The Go binary embeds the schema at build time (`internal/spec/schema_embed.json`); new optional fields are picked up on the next server release
 - The Logos docs `logosTeamSchema.js` is a separate display representation and must be kept in sync with `schema/team.schema.json` manually or via a generator — it is the known maintenance surface
 - Adding a new agent capability requires only new MCP tools, not changes to existing agents
+
+### Plugins for Cross-Cutting Capabilities; Instructions Stay as Instructions
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>June 2026</td><td>Platform</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+Copilot customizations were distributed by mechanism-specific means: custom instructions via the shell-scoped `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` env var, skills and agents auto-loaded only when Copilot ran inside their home repo, and the MCP server registered by hand from a README with an unpinned image. There was no versioned, discoverable distribution path for cross-cutting capabilities, and the env var fails silently when Copilot is launched from a shell, GUI, or CI step that never sourced the profile.
+
+#### Decision
+
+Adopt GitHub Copilot CLI plugins and a group-owned marketplace (`pt-ai-plugins`, registry `osinfra-io`) for distributable **capabilities** — skills, agents, and MCP servers. Keep **custom instructions exactly as they are**: the `plugin.json` manifest has no field for `copilot-instructions.md` or `*.instructions.md`, so instructions remain on `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`, per-repo files, and the VS Code setting. Team-owned plugins are **federated** — their manifest lives in the team repo and the marketplace references it, never copying files.
+
+#### Alternatives Considered
+
+- **Full adoption (migrate everything, including instructions)** — Rejected. Plugins cannot package custom instructions, which are the bulk of the current setup.
+- **Do nothing** — Rejected. Misses a clean, versioned, discoverable distribution path for cross-cutting skills and the onboarding agent plus MCP bundle.
+- **Centralized vendoring (copy team agents and MCP config into the marketplace repo)** — Rejected. Duplicates files and drifts; a vendored copy of the Nomos agent would also be invisible to its Promptfoo evaluations.
+
+#### Consequences
+
+- Capabilities install once and work from any directory, fixing the env var's silent-failure mode for the things that become plugins
+- Plugins carry a semantic `version` and update via `copilot plugin update`; federated sources pin to the team repo
+- Instructions remain unversioned and shell-scoped — unchanged, because they cannot be packaged
+- The MCP image must be pinned to a release tag (not `:latest`) for a federated plugin to be trustworthy


### PR DESCRIPTION
## What

- Adds a **Plugins and marketplace** section to `docs/platform-grouping/techne/ai-tooling.md` and a new ADR.
  - Describes [`pt-ai-plugins`](https://github.com/osinfra-io/pt-ai-plugins) (registry `osinfra-io`) and its two plugins: `platform-conventions` (group-owned skills) and `techne-onboarding` (the Nomos agent + `pt-techne-mcp-server`, **federated** from `pt-techne-agents`).
  - **ADR: Plugins for cross-cutting capabilities; instructions stay as instructions** — records the decision to adopt plugins for distributable capabilities while keeping custom instructions on `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (the `plugin.json` manifest has no field for instructions), and the rejection of full migration and centralized vendoring.
- Updates `docs/onboarding.mdx` — the **Copilot CLI** invocation card now installs the `techne-onboarding` plugin and runs `copilot` from any directory, replacing the clone-and-`gh copilot` flow. Installing the plugin also auto-registers the `pt-techne-mcp-server` tools. (GitHub UI and VS Code cards unchanged; the GitHub MCP token warning still applies.)

## Why

Documentation must track platform behavior. This follows the new `pt-ai-plugins` marketplace and the `techne-onboarding` federation in `pt-techne-agents`, so the docs no longer omit the plugins distribution layer — including the onboarding page teams actually follow.

## Related

- osinfra-io/pt-ai-plugins#1 — the marketplace and `platform-conventions` plugin
- osinfra-io/pt-techne-agents#27 — the federated `techne-onboarding` plugin manifest
- osinfra-io/pt-ai-context#11 — cross-reference from the instruction hierarchy

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for `pt-ai-plugins`, including a new “Plugins and marketplace” section with capabilities and federated setup guidance.
  * Updated Architecture Decision Records with the adopted approach for cross-cutting capabilities via Copilot CLI plugins, plus key constraints for federated plugins.
  * Refreshed Copilot CLI onboarding steps to install and run using the onboarding plugin (including the automatic tool registration note for the Nomos Agent flow).
  * Standardized ADR section headings from “Decisions” to “Decision” across relevant documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->