### PR TITLE
Standardize ADR heading on singular Decision and make Links optional

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -186,10 +186,9 @@ Each ADR follows this structure:
 
 <What forced this decision and why it was non-trivial.>
 
-#### Decisions
+#### Decision
 
-1. **<Decision>.** <Rationale.>
-2. **<Decision>.** <Rationale.>
+<The decision and its rationale.>
 
 #### Alternatives Considered
 
@@ -198,10 +197,8 @@ Each ADR follows this structure:
 #### Consequences
 
 - <Bullet list of outcomes, constraints, or follow-on requirements.>
-
-#### Links
-
-- [<Link text>](<url>)
 ```
+
+The `#### Links` section is optional — include a final bulleted list of external references only when the ADR cites them.
 
 See `docs/platform-grouping/corpus/networking.md` for a complete example.

--- a/docs/platform-grouping/corpus/networking.md
+++ b/docs/platform-grouping/corpus/networking.md
@@ -171,7 +171,7 @@ Each cluster is a regional cluster with a single zonal node pool (e.g., `pt-pneu
 
 The guiding principle throughout: **use GKE defaults unless there is a clear reason not to.**
 
-#### Decisions
+#### Decision
 
 1. **Carve `10.0.0.0/8` into four `/10` blocks.** Each `/10` is large enough for 30 clusters. Four blocks give the platform room to grow across independent address spaces without redesign.
 

--- a/docs/platform-grouping/pneuma/cluster-management.md
+++ b/docs/platform-grouping/pneuma/cluster-management.md
@@ -76,7 +76,7 @@ Kubernetes workload environments require more than just a cluster — they need 
 
 The platform also needs a clear scaling model for clusters. Sizing a single large cluster per environment requires predicting peak load. Cluster failure affects all tenants. Regional failure affects all zones at once.
 
-#### Decisions
+#### Decision
 
 1. **Regional clusters with zone-scoped node pools.** Each cluster has a regional control plane (highly available across three zones) but a single-zone node pool — one cluster per zone (e.g., `pt-pneuma-us-east1-b`, `pt-pneuma-us-east4-a`). Keeping node pools zone-local ensures Istio's locality-aware load balancing routes traffic within the zone by default, preventing cross-zone hot spots in the mesh. Clusters scale by adding zones, not by growing individual cluster size. Each cluster is independently managed, independently upgradeable, and independently recoverable.
 

--- a/docs/platform-grouping/pneuma/index.md
+++ b/docs/platform-grouping/pneuma/index.md
@@ -106,7 +106,7 @@ Pneuma operates 5 working domains against the Team Topologies recommended limit 
 
 The five domains — Cluster Management, Service Mesh, Certificate Management, Policy Enforcement, and Observability — cannot be separated without creating artificial coupling problems. cert-manager CRDs must exist before Istio certificate resources; OPA Gatekeeper runs against all workloads on the cluster. Splitting these concerns across teams would require tight coordination at every upgrade cycle and introduce more extraneous load than the split would remove.
 
-#### Decisions
+#### Decision
 
 1. **Accept the 🔴 overload state as a managed risk.** The five domains are operationally inseparable at the cluster layer. This is a structural reality of the platform, not a resourcing failure. The risk is acknowledged, documented, and mitigated — not ignored.
 


### PR DESCRIPTION
## What

Aligns the documented ADR template in `.github/copilot-instructions.md` with actual practice:

- **`#### Decision`** — always singular (never `#### Decisions`), matching the `## Core Invariant(s)` precedent already in the same file and 11 of 14 existing ADRs.
- **`#### Links`** — now documented as **optional**: include it only when the ADR cites external references.

Also normalizes the three ADRs that still used plural `#### Decisions` so the repo is internally consistent (and so the cited "complete example", `corpus/networking.md`, matches the template):

- `docs/platform-grouping/corpus/networking.md`
- `docs/platform-grouping/pneuma/cluster-management.md`
- `docs/platform-grouping/pneuma/index.md`

Heading rename only — numbered-list bodies and `networking.md`'s `#### Links` section are unchanged.

## Why

The template mandated plural `#### Decisions` and an always-present `#### Links` section, which diverged from how ADRs are actually written and triggered a false-positive review finding on a compliant single-decision ADR. Fixing the source of truth stops agents and review bots from flagging correct ADRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Records (ADR) template for improved clarity and consistency.
  * Standardized decision section naming across documentation.
  * Clarified that external reference links in ADRs are optional and only included when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->