### PR TITLE
Document platform-owned clusters with team-scoped namespace administration

### DIFF
--- a/docs/platform-grouping/pneuma/cluster-management.md
+++ b/docs/platform-grouping/pneuma/cluster-management.md
@@ -8,11 +8,13 @@ Pneuma is the **central cluster provisioner** for the platform. It reads all tea
 
 - **GKE clusters**: Teams declare cluster locations in their Logos team spec under `platform_managed_project.kubernetes_engine`. Pneuma provisions a regional GKE cluster for each declared location — regional control plane (highly available across three zones) with one node pool per zone (e.g., `pt-pneuma-us-east1-b`). Zone-scoped node pools ensure Istio's locality-aware load balancing keeps traffic within a zone, eliminating cross-zone hot spots in the mesh. Clusters are CIS GKE Benchmark hardened and Fleet-enrolled for multi-cluster ingress.
 - **Workload Identity**: Kubernetes service accounts are mapped to GCP service accounts, eliminating node-level credential access
-- **Namespace onboarding**: A dedicated onboarding workspace in the Pneuma pipeline creates Kubernetes namespaces and Workload Identity bindings per team. It runs automatically within the same pipeline after the zonal cluster job completes — no separate trigger is needed once the pipeline starts. The Pneuma pipeline itself triggers on every merge to `pt-pneuma` main, or a platform engineer can trigger it immediately via `workflow_dispatch`.
+- **Namespace onboarding**: A dedicated onboarding workspace in the Pneuma pipeline creates Kubernetes namespaces per team, provisions a Workload Identity service account for each namespace, and binds the team's GitHub Actions service account as a namespace-scoped administrator (RBAC). It runs automatically within the same pipeline after the zonal cluster job completes — no separate trigger is needed once the pipeline starts. The Pneuma pipeline itself triggers on every merge to `pt-pneuma` main, or a platform engineer can trigger it immediately via `workflow_dispatch`.
 
 ## Namespace Provisioning
 
 Namespaces are **driven by Logos team data** — each team declares `kubernetes_engine.namespaces` in their team spec via the Nomos Agent. Each team's onboarding workspace reads its own namespace configuration from `module.core_helpers.teams[team]` and provisions those namespaces into that team's own GKE clusters. No pull request to the cluster-owning team's repo is required.
+
+Pneuma **owns the clusters; each team owns the namespaces it declares within its own cluster.** For every namespace it creates, Pneuma provisions a dedicated Workload Identity service account and binds the team's GitHub Actions service account (created in Corpus) as a namespace-scoped `namespace-admin` via Kubernetes RBAC. This lets a stream-aligned team deploy its own workloads into its namespaces — from its own GitHub Actions pipelines — without granting any access to another team's namespaces or to the cluster itself. A per-namespace Workload Identity service account is always provisioned; teams no longer supply a service account in the namespace spec.
 
 Corpus and Pneuma are triggered independently — there is no automatic cascade from a Logos PR merge. A platform engineer must either merge a pending PR to each repo or manually trigger their `workflow_dispatch` workflow. Once the cluster-owning team's pipeline runs, the onboarding workspace applies namespace configuration automatically — no additional action is required.
 
@@ -87,3 +89,43 @@ Each layer maps to a dedicated subdirectory workspace in `pt-pneuma`, deployed i
 - Add-on upgrades (e.g., Istio minor version) are applied per cluster without touching cluster infrastructure
 - Teams control their cluster configuration through Logos — adding or changing a cluster requires only a Nomos Agent PR, no changes to `pt-pneuma`
 - Adding a new zone requires claiming a CIDR slot from the Corpus IPAM plan
+
+### Platform-Owned Clusters with Team-Scoped Namespace Administration
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Pneuma</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+Stream-aligned teams need to deploy their own workloads into their own clusters from their own CI/CD pipelines. The platform team has high trust in each stream-aligned team within that team's own boundary, but trust **between** stream-aligned teams is deliberately low — one team must never be able to read or mutate another team's namespaces, and no team should be able to reconfigure the cluster itself.
+
+Provisioning also needs a single source of truth. Letting each team manage namespaces from its own repository would fragment cluster access, duplicate provider wiring across many pipelines, and make cluster-wide invariants (naming, Workload Identity, sidecar policy) impossible to enforce centrally.
+
+#### Decision
+
+Pneuma provisions namespaces and Kubernetes add-ons across **every** team's clusters from a single pipeline, iterating all teams' clusters via a per-cluster Kubernetes and Helm provider `for_each`. The cluster set is sourced from Logos team data and passed to each zone workspace as an input variable so it satisfies OpenTofu's static requirement for provider `for_each`.
+
+The platform team owns the clusters; each stream-aligned team owns the namespaces it declares within its own cluster. For every namespace it creates, Pneuma:
+
+- provisions a dedicated Workload Identity service account, and
+- binds that team's GitHub Actions service account (created in Corpus) as a **namespace-scoped `namespace-admin`** via Kubernetes RBAC.
+
+A team's GitHub Actions pipeline can therefore deploy workloads into its own namespaces without any access to another team's namespaces or to cluster-scoped resources. The per-namespace Workload Identity service account is always provisioned, so the namespace spec no longer carries an optional service account field.
+
+#### Alternatives Considered
+
+- **Each team provisions its own namespaces from its own repository** — Rejected. Fragments cluster credentials across many pipelines, duplicates provider wiring, and prevents the platform team from enforcing cluster-wide invariants. It also requires per-team workflow plumbing in every sibling workspace, which does not scale.
+- **Grant each team's GitHub Actions service account cluster-admin** — Rejected. Violates the low inter-team trust boundary. A cluster-admin binding would let any team read or mutate every other team's namespaces and reconfigure the cluster.
+
+#### Consequences
+
+- One pipeline (`pt-pneuma`) provisions namespaces and add-ons for all teams; cluster-wide invariants are enforced centrally
+- Each team's GitHub Actions service account can self-serve deployments into its own namespaces, but cannot touch another team's namespaces or the cluster itself
+- Every namespace is guaranteed a Workload Identity service account; runtime GCP-API bindings for a workload are requested separately through the Nomos Agent when needed
+- The cluster set must reach each zone workspace as an input variable (`TF_VAR_clusters`), because provider `for_each` cannot read module outputs or remote state — the deployment workflow passes the main workspace's `clusters` output into each zone job

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -58,11 +58,7 @@ Traffic to `kryptos.sb.osinfra.io` enters pneuma's gateway, which applies the Vi
 
 All VirtualServices — including those for member team hosts — are defined on pneuma's clusters in the `istio-ingress` namespace. VirtualService destinations reference services by their fully-qualified in-cluster DNS name.
 
-Member team namespaces receive a team-key prefix when provisioned: a namespace declared as `openbao` in the kryptos team spec is created as `pt-kryptos-openbao` in the cluster. This prefix scopes the in-cluster service DNS to that team's own clusters:
-
-```
-istio-test.pt-kryptos-istio-test.svc.cluster.local
-```
+Member team namespaces receive a team-key prefix when provisioned: a namespace declared as `openbao` in the kryptos team spec is created as `pt-kryptos-openbao` in the cluster. This prefix scopes the in-cluster service DNS to that team's own clusters: `istio-test.pt-kryptos-istio-test.svc.cluster.local`.
 
 Fleet endpoint discovery only finds pods matching this service name on kryptos clusters — there are no pods with that service name on any other cluster. The VirtualService destination therefore routes exclusively to kryptos, without any explicit DestinationRule subset or locality filter. Adding a new team cluster automatically extends this isolation: each team's namespace prefix is globally unique in the mesh.
 

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -4,24 +4,146 @@ sidebar_label: Service Mesh
 
 # Service Mesh
 
-Istio is deployed on every GKE cluster, providing mTLS between services, fine-grained traffic management, and an ingress gateway backed by Cloud Armor WAF protection.
+Istio is deployed on every GKE cluster as part of a single multi-cluster mesh, providing mTLS between services, fine-grained traffic management, and an ingress gateway backed by Cloud Armor WAF protection. All clusters join a GKE Fleet, which enables cross-cluster endpoint discovery — pods on member team clusters are reachable from VirtualServices defined on pneuma clusters without any manual endpoint configuration.
 
-- **mTLS**: All service-to-service traffic within the mesh is encrypted and authenticated automatically
-- **Traffic management**: Istio VirtualServices and DestinationRules control routing, retries, and timeouts
-- **Ingress gateway**: External traffic enters the mesh through a managed gateway with Datadog AAP (Application and API Protection) deployed as an Envoy external processor for WAF and threat detection
-- **cert-manager integration**: Istio's built-in CA is replaced by cert-manager via istio-csr, which issues and rotates all workload mTLS certificates in the mesh
+- **mTLS**: All service-to-service traffic within the mesh is encrypted and authenticated automatically via istiod, which runs on every cluster
+- **Traffic management**: Istio VirtualServices and DestinationRules control routing, retries, and timeouts — all defined on gateway clusters and applied fleet-wide
+- **Ingress gateway**: External traffic enters the mesh exclusively through pneuma's managed gateway, backed by Cloud Armor WAF and Datadog AAP (Application and API Protection) deployed as an Envoy external processor for WAF and threat detection
+- **cert-manager integration**: Istio's built-in CA is replaced by cert-manager via istio-csr, which issues and rotates all workload mTLS certificates across the entire mesh
+
+:::tip Architecture Decision Records
+
+This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
+
+:::
 
 ## Components
 
 | Component | Description |
 |---|---|
-| `istio-control-plane` | The Istio control plane deployed via Helm, managing traffic policy across the mesh |
-| `ingress-gateway` | A managed ingress gateway exposed via a GCP load balancer |
+| `istio-control-plane` | The Istio control plane (istiod) deployed via Helm on every cluster — manages traffic policy and mTLS certificate distribution |
+| `ingress-gateway` | A managed ingress gateway deployed only on pneuma clusters, exposed via a GCP Multi-Cluster Ingress global load balancer and zonal load balancers |
 | `waf-policy` | A Cloud Armor security policy attached to the ingress gateway (OWASP rules, rate limiting, adaptive DDoS) |
-| `virtual-service` | An Istio routing rule defining traffic behavior for a service (retries, timeouts, fault injection) |
+| `virtual-service` | An Istio routing rule defining traffic behavior for a service — all VirtualServices for all teams are defined on pneuma's gateway clusters |
 | `destination-rule` | An Istio policy defining connection pool and circuit breaker settings for a destination |
 | `peer-authentication` | A mesh-wide policy enforcing strict mTLS between all services |
 
-## Core Invariant
+## Multi-Cluster Mesh
 
-mTLS is enforced on every cluster via Istio — no plaintext pod-to-pod traffic.
+All GKE clusters — both pneuma's own clusters and member team clusters (e.g., kryptos) — join a GKE Fleet and form a single Istio service mesh. Fleet membership enables cross-cluster endpoint discovery: a VirtualService defined on a pneuma cluster can route traffic to a pod running on a member team cluster with no additional configuration.
+
+Each cluster runs its own istiod instance for local mTLS policy enforcement and sidecar injection. Clusters are not coupled at the control plane level — each istiod operates independently, and a control plane failure on one cluster does not affect workloads on another.
+
+### Gateway and Member Cluster Roles
+
+Clusters have one of two roles in the mesh:
+
+| Role | Clusters | Responsibilities |
+|---|---|---|
+| **Gateway** | `pt-pneuma-*` | Runs the Istio ingress gateway, MCI global load balancer, Cloud Armor WAF, Datadog AAP, and all VirtualServices for all teams |
+| **Member** | `pt-kryptos-*` (and future team clusters) | Runs istiod for mTLS and sidecar injection; no gateway, no VirtualServices — receives traffic forwarded from the gateway via the mesh |
+
+### DNS and Ingress Routing
+
+All external DNS for every team subdomain points to pneuma's gateway IPs — even for member team clusters:
+
+| Record | Target |
+|---|---|
+| `{team}.{env}.osinfra.io` | Pneuma's MCI global IP (anycast, routes to lowest-latency zone) |
+| `{zone}.{team}.{env}.osinfra.io` | Pneuma's zonal load balancer in that zone |
+
+Traffic to `kryptos.sb.osinfra.io` enters pneuma's gateway, which applies the VirtualService for that host and forwards the request across the mesh to the kryptos cluster. The kryptos cluster has no public IP and no gateway.
+
+### VirtualService Routing and Team Namespace Isolation
+
+All VirtualServices — including those for member team hosts — are defined on pneuma's clusters in the `istio-ingress` namespace. VirtualService destinations reference services by their fully-qualified in-cluster DNS name.
+
+Member team namespaces receive a team-key prefix when provisioned: a namespace declared as `openbao` in the kryptos team spec is created as `pt-kryptos-openbao` in the cluster. This prefix scopes the in-cluster service DNS to that team's own clusters:
+
+```
+istio-test.pt-kryptos-istio-test.svc.cluster.local
+```
+
+Fleet endpoint discovery only finds pods matching this service name on kryptos clusters — there are no pods with that service name on any other cluster. The VirtualService destination therefore routes exclusively to kryptos, without any explicit DestinationRule subset or locality filter. Adding a new team cluster automatically extends this isolation: each team's namespace prefix is globally unique in the mesh.
+
+### End-to-End Validation
+
+The `istio-test` workspace deploys a lightweight metadata service in each team's istio-test namespace (`istio-test` on pneuma, `pt-{team_key}-istio-test` on member clusters). A validation script checks every global and zonal endpoint and confirms the returned cluster name contains the expected team subdomain and zone, verifying that traffic routes to the correct cluster.
+
+## Core Invariants
+
+- mTLS is enforced on every cluster via `PeerAuthentication` in strict mode — no plaintext pod-to-pod traffic.
+- The Istio ingress gateway runs only on pneuma clusters — no member team cluster accepts external traffic directly.
+- All VirtualServices for all teams are managed centrally by pneuma — no team defines its own ingress routing.
+- Member team namespace names carry the team-key prefix (`{team_key}-{namespace}`) — no two teams can collide on a service DNS name within the mesh.
+
+## Architecture Decision Records
+
+### Single Gateway Owner with Fleet-Wide Mesh
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Pneuma</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+The platform runs multiple GKE clusters — one set owned by pneuma and additional sets owned by member teams (e.g., kryptos). All clusters must be reachable from the public internet without each team managing its own ingress gateway, SSL certificate, WAF policy, and global load balancer. Duplicating that infrastructure per team adds cost, operational overhead, and inconsistent security posture across teams.
+
+#### Decision
+
+Pneuma is the sole gateway owner. Only pneuma clusters run the Istio ingress gateway, MCI global load balancer, Cloud Armor WAF policy, and Datadog AAP external processor. All external DNS — including DNS for member team subdomains — points to pneuma's gateway IPs. VirtualServices for all team hosts are defined centrally on pneuma's clusters and route traffic across the GKE Fleet mesh to the correct member cluster.
+
+Member team clusters join the Fleet and run istiod for local mTLS and sidecar injection. They have no public endpoint of their own; they receive traffic exclusively via the cross-cluster mesh from pneuma's gateway.
+
+#### Alternatives Considered
+
+- **Each team runs its own ingress gateway** — Rejected. Multiplies WAF policies, SSL certificates, Cloud Armor configs, and MCI global addresses per team. Each team's pipeline would need to manage GCP load balancer infrastructure in addition to Kubernetes workloads, and security posture diverges over time.
+- **Shared ingress namespace on a single cluster** — Rejected. Ties all external traffic to one cluster's availability. GKE Fleet MCI with a gateway-owning cluster set achieves multi-zone resilience without coupling availability to a single node.
+
+#### Consequences
+
+- All external TLS termination, WAF inspection, and threat detection happens at a single controlled point (pneuma gateway) for every team
+- Adding a new team cluster requires only a Logos spec change — Corpus creates the team's DNS zone and pneuma provisions its VirtualServices; no gateway or load balancer changes are needed
+- Pneuma's gateway clusters are critical infrastructure — their availability determines the reachability of every team's workloads
+- All VirtualServices are centrally managed; teams cannot define custom ingress routing without a pneuma change
+
+### Team-Prefixed Namespace Isolation in the Mesh
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Pneuma</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+With all clusters in a single Fleet mesh, cross-cluster endpoint discovery means a VirtualService on a pneuma cluster can route to any pod in any namespace on any cluster. If two teams deploy a service with the same name in the same namespace name (e.g., `istio-test/istio-test`), fleet discovery aggregates their endpoints and a VirtualService destination becomes non-deterministic — it may route to either team's cluster depending on load and locality.
+
+E2E validation requires that traffic to `kryptos.sb.osinfra.io` reaches only a kryptos cluster. Without namespace isolation, the destination `istio-test.istio-test.svc.cluster.local` would resolve to endpoints on all clusters in the mesh.
+
+#### Decision
+
+All member team namespaces are provisioned with a team-key prefix: a namespace declared as `{name}` in the team spec is created as `{team_key}-{name}` in the cluster (e.g., `pt-kryptos-openbao`, `pt-kryptos-istio-test`). Pneuma's own namespaces are unchanged.
+
+VirtualService destinations for member team services reference the prefixed namespace: `{service}.{team_key}-{namespace}.svc.cluster.local`. Because no other team uses this prefix, fleet endpoint discovery only returns pods from the owning team's clusters. Cluster-level isolation is achieved through naming — no explicit DestinationRule subset or locality filter is needed.
+
+#### Alternatives Considered
+
+- **Explicit DestinationRule subsets with cluster labels** — Rejected. Requires a DestinationRule per team per service, plus consistent cluster labels across the fleet. More configuration surface area that must be kept in sync with team topology changes.
+- **Locality failover rules** — Rejected. Locality load balancing routes by proximity to the gateway, not by cluster ownership. It cannot guarantee traffic stays within a specific team's cluster when teams have clusters in the same zone.
+- **Separate gateways per team with different selectors** — Rejected. Requires each team to run its own gateway, which contradicts the single-gateway-owner decision.
+
+#### Consequences
+
+- Each team's namespace DNS is globally unique in the mesh — no cross-team endpoint aggregation is possible
+- Namespace names visible to end users (in Logos team specs and Nomos) remain unprefixed; the prefix is a platform-internal implementation detail applied at provision time
+- The `istio-test` E2E validation is reliable: `kryptos.sb.osinfra.io` provably reaches only kryptos clusters
+- Any team accidentally including their own team-key prefix in a namespace name would produce a double-prefixed name — schema validation does not currently prevent this edge case


### PR DESCRIPTION
## What changed

Updates the Pneuma **Cluster Management** page to reflect the team-based namespace provisioning model:

- **Namespace Provisioning** section now states that Pneuma owns the clusters while each stream-aligned team owns the namespaces it declares within its own cluster. For every namespace it creates, Pneuma provisions a Workload Identity service account **and** binds the team's GitHub Actions service account as a namespace-scoped `namespace-admin` (RBAC).
- Clarifies that a per-namespace Workload Identity service account is **always** provisioned — the optional per-namespace service account field was removed.
- Adds an ADR: **Platform-Owned Clusters with Team-Scoped Namespace Administration**, capturing the trust model (high trust within a team, low trust between teams), the per-cluster provider `for_each` mechanism, and the `TF_VAR_clusters` input-variable constraint.

## Why

Documents the platform-wide refactor where `pt-pneuma` provisions namespaces and add-ons across all teams' clusters, keeping the docs in sync with the code changes across `pt-pneuma`, `pt-logos`, `pt-arche-*`, `pt-techne-*`.

## Verification

- `yarn build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined namespace onboarding guidance to clarify responsibility boundaries and automated provisioning of per-namespace Workload Identity and Kubernetes RBAC, including removal of optional team-supplied service account details.
  * Added an architecture decision record: “Platform-Owned Clusters with Team-Scoped Namespace Administration.”
  * Rewrote the service mesh documentation into a GKE Fleet multi-cluster architecture overview, including centralized ingress gateway ownership, routing/discovery behavior, strict mTLS posture, end-to-end validation, and related architecture decision records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->