### PR TITLE
Update Identity & Access docs for per-environment groups

### DIFF
--- a/docs/platform-grouping/logos/identity-access.md
+++ b/docs/platform-grouping/logos/identity-access.md
@@ -39,19 +39,18 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 
 #### Context and Problem Statement
 
-Each team previously had three Google Cloud Identity groups (admin, reader, writer) bound to the team folder via IAM. Because GCP IAM inherits down the folder hierarchy, all three environment folders (sandbox, non-production, production) received identical access. There was no way to grant write access in sandbox or non-production while restricting production to read-only for a given user.
+GCP IAM bindings applied at a folder level inherit to all child folders. Team identity groups bound at the team folder grant the same access across all environments, making it impossible to allow write access in sandbox or non-production while restricting production to read-only.
 
 #### Decision
 
-Replace the three team-folder groups with nine per-environment groups (3 roles × 3 environments), each bound directly to its corresponding environment folder. Group emails follow the pattern `{team-key}-{environment}-{role-plural}@osinfra.io` (e.g. `pt-arche-production-administrators@osinfra.io`). Membership for each role can now differ per environment, giving teams fine-grained access control without custom IAM policies.
+Each team has nine Google Cloud Identity groups (3 roles × 3 environments), each bound directly to its corresponding environment folder. Group emails follow the pattern `{team-key}-{environment}-{role-plural}@osinfra.io` (e.g. `pt-arche-production-administrators@osinfra.io`). Membership for each role is configured independently per environment in `teams/*.tfvars` under `google_basic_groups_env_memberships`.
 
 #### Alternatives Considered
 
-- **Keep team-folder binding, add environment-level deny policies** — deny policies are harder to reason about, audit, and manage as code; explicit group membership is clearer.
-- **Project-level IAM** — projects are provisioned by Corpus, not Logos; binding at the environment folder is the correct layer for team-wide access and consistent with how Corpus already scopes its own service account groups.
+- **Team-folder binding with environment-level deny policies** — deny policies are harder to reason about, audit, and manage as code; explicit group membership is clearer.
+- **Project-level IAM** — projects are provisioned by Corpus, not Logos; binding at the environment folder is the correct layer for team-wide access and consistent with how Corpus scopes its own service account groups.
 
 #### Consequences
 
-- Teams gain the ability to grant different access levels per environment (e.g. writer in sandbox, reader in production).
-- Each team now has 9 identity groups instead of 3; existing 3-group configurations are destroyed and replaced on next apply.
-- Membership must be specified per environment in `teams/*.tfvars` under `google_basic_groups_env_memberships`.
+- Teams can grant different access levels per environment (e.g. writer in sandbox and non-production, reader in production).
+- Membership must be specified per environment, which requires more configuration than a single shared membership block.

--- a/docs/platform-grouping/logos/identity-access.md
+++ b/docs/platform-grouping/logos/identity-access.md
@@ -6,14 +6,52 @@ sidebar_label: Identity & Access
 
 Logos manages centralized identity and access control for the platform. Google Identity groups map team boundaries to GCP IAM, ensuring access is granted to groups rather than individuals.
 
-- **Team identity groups**: Three standard groups per team (admin, reader, writer) controlling access to team GCP resources, with membership managed as code
+- **Team identity groups**: Nine groups per team (admin, reader, writer × sandbox, non-production, production) bound directly to environment folders, enabling per-environment access control with membership managed as code
 - **GKE security groups**: An organization-wide security group used for Kubernetes RBAC across all GKE clusters; team identity groups are nested as members
 - **Billing users group**: An organization-wide group that grants the billing user IAM role, used by team service accounts that need to associate projects with the billing account
+
+:::tip Architecture Decision Records
+
+This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
+
+:::
 
 ## Components
 
 | Component | Description |
 |---|---|
-| `identity-group` | A Google Identity group scoped to a team and environment (e.g., `pt-corpus-admins`) |
+| `identity-group` | A Google Identity group scoped to a team, environment, and role (e.g., `pt-corpus-sandbox-administrators`) |
 | `user` | A platform user provisioned into one or more identity groups |
-| `iam-binding` | A mapping of an identity group to a GCP role at a resource scope |
+| `iam-binding` | A mapping of an identity group to a GCP role on an environment folder |
+
+## Architecture Decision Records
+
+### Per-environment Google Cloud Identity groups
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Platform Team</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+Each team previously had three Google Cloud Identity groups (admin, reader, writer) bound to the team folder via IAM. Because GCP IAM inherits down the folder hierarchy, all three environment folders (sandbox, non-production, production) received identical access. There was no way to grant write access in sandbox or non-production while restricting production to read-only for a given user.
+
+#### Decision
+
+Replace the three team-folder groups with nine per-environment groups (3 roles × 3 environments), each bound directly to its corresponding environment folder. Group emails follow the pattern `{team-key}-{environment}-{role-plural}@osinfra.io` (e.g. `pt-arche-production-administrators@osinfra.io`). Membership for each role can now differ per environment, giving teams fine-grained access control without custom IAM policies.
+
+#### Alternatives Considered
+
+- **Keep team-folder binding, add environment-level deny policies** — deny policies are harder to reason about, audit, and manage as code; explicit group membership is clearer.
+- **Project-level IAM** — projects are provisioned by Corpus, not Logos; binding at the environment folder is the correct layer for team-wide access and consistent with how Corpus already scopes its own service account groups.
+
+#### Consequences
+
+- Teams gain the ability to grant different access levels per environment (e.g. writer in sandbox, reader in production).
+- Each team now has 9 identity groups instead of 3; existing 3-group configurations are destroyed and replaced on next apply.
+- Membership must be specified per environment in `teams/*.tfvars` under `google_basic_groups_env_memberships`.

--- a/docs/platform-grouping/logos/identity-access.md
+++ b/docs/platform-grouping/logos/identity-access.md
@@ -10,12 +10,6 @@ Logos manages centralized identity and access control for the platform. Google I
 - **GKE security groups**: An organization-wide security group used for Kubernetes RBAC across all GKE clusters; team identity groups are nested as members
 - **Billing users group**: An organization-wide group that grants the billing user IAM role, used by team service accounts that need to associate projects with the billing account
 
-:::tip Architecture Decision Records
-
-This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
-
-:::
-
 ## Components
 
 | Component | Description |
@@ -23,34 +17,3 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 | `identity-group` | A Google Identity group scoped to a team, environment, and role (e.g., `pt-corpus-sandbox-administrators`) |
 | `user` | A platform user provisioned into one or more identity groups |
 | `iam-binding` | A mapping of an identity group to a GCP role on an environment folder |
-
-## Architecture Decision Records
-
-### Per-environment Google Cloud Identity groups
-
-<table>
-  <thead>
-    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
-  </thead>
-  <tbody>
-    <tr><td>Accepted ✅</td><td>July 2026</td><td>Platform Team</td></tr>
-  </tbody>
-</table>
-
-#### Context and Problem Statement
-
-GCP IAM bindings applied at a folder level inherit to all child folders. Team identity groups bound at the team folder grant the same access across all environments, making it impossible to allow write access in sandbox or non-production while restricting production to read-only.
-
-#### Decision
-
-Each team has nine Google Cloud Identity groups (3 roles × 3 environments), each bound directly to its corresponding environment folder. Group emails follow the pattern `{team-key}-{environment}-{role-plural}@osinfra.io` (e.g. `pt-arche-production-administrators@osinfra.io`). Membership for each role is configured independently per environment in `teams/*.tfvars` under `google_basic_groups_env_memberships`.
-
-#### Alternatives Considered
-
-- **Team-folder binding with environment-level deny policies** — deny policies are harder to reason about, audit, and manage as code; explicit group membership is clearer.
-- **Project-level IAM** — projects are provisioned by Corpus, not Logos; binding at the environment folder is the correct layer for team-wide access and consistent with how Corpus scopes its own service account groups.
-
-#### Consequences
-
-- Teams can grant different access levels per environment (e.g. writer in sandbox and non-production, reader in production).
-- Membership must be specified per environment, which requires more configuration than a single shared membership block.

--- a/src/components/SchemaViewer/team.schema.json
+++ b/src/components/SchemaViewer/team.schema.json
@@ -11,7 +11,7 @@
     "display_name",
     "display_name_comment",
     "github_parent_team_memberships",
-    "google_basic_groups_memberships",
+    "google_basic_groups_env_memberships",
     "team_type"
   ],
   "properties": {
@@ -77,8 +77,8 @@
         "$ref": "#/$defs/githubRepository"
       }
     },
-    "google_basic_groups_memberships": {
-      "description": "Google Cloud Identity basic groups: admin, reader, writer.",
+    "google_basic_groups_env_memberships": {
+      "description": "Per-environment Google Cloud Identity basic groups: admin, reader, writer. Binds each role directly to environment folders — no team-folder binding, no inheritance. Allows finer-grained access control than team-level groups (e.g. write in sandbox/non-production, read-only in production).",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -88,13 +88,13 @@
       ],
       "properties": {
         "admin": {
-          "$ref": "#/$defs/googleGroup"
+          "$ref": "#/$defs/envScopedGoogleGroups"
         },
         "reader": {
-          "$ref": "#/$defs/googleGroup"
+          "$ref": "#/$defs/envScopedGoogleGroups"
         },
         "writer": {
-          "$ref": "#/$defs/googleGroup"
+          "$ref": "#/$defs/envScopedGoogleGroups"
         }
       }
     },
@@ -616,10 +616,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "google_service_account": {
-          "description": "Email of the GCP service account to bind to the Kubernetes service account in this namespace via Workload Identity. When omitted, the namespace is created but no Workload Identity binding is provisioned.",
-          "type": "string"
-        },
         "istio_injection": {
           "description": "Whether to enable Istio sidecar injection in this namespace. Defaults to disabled.",
           "type": "string",


### PR DESCRIPTION
Updates the Logos Identity & Access page to reflect the nine-group structure (admin/reader/writer × sandbox/non-production/production) and syncs the `team.schema.json` copy with `pt-techne-mcp-server`.

Relates to osinfra-io/pt-logos#153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated identity and access documentation to describe nine environment-specific groups per team.
  * Clarified how identity groups and IAM bindings are scoped to teams, environments, roles, and environment folders.
  * Added role-specific naming examples for identity groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->