### PR TITLE
Sync route_prefix into the team schema viewer

### DIFF
--- a/src/components/SchemaViewer/team.schema.json
+++ b/src/components/SchemaViewer/team.schema.json
@@ -536,6 +536,11 @@
           "additionalProperties": {
             "$ref": "#/$defs/gkeNamespaceEntry"
           }
+        },
+        "route_prefix": {
+          "description": "DNS label the team owns for HTTP ingress on the shared Istio Gateway. Becomes the subdomain <route-prefix>.osinfra.io and the value of the osinfra.io/route-prefix namespace label that scopes the team's Gateway listener. Unlike dns_subdomain it does not require the team to own clusters. Must be lowercase letters, digits, and hyphens, starting with a letter.",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
         }
       }
     },


### PR DESCRIPTION
## What

Syncs `src/components/SchemaViewer/team.schema.json` (the single source of truth the Team Topology page and the onboarding PromptBuilder render from) with the canonical schema in [`pt-techne-mcp-server`](https://github.com/osinfra-io/pt-techne-mcp-server/pull/69), which now includes the new `kubernetes_engine.route_prefix` field.

## Why

Per the pt-logos schema-propagation rule, adding `route_prefix` to the `teams` variable ([pt-logos#192](https://github.com/osinfra-io/pt-logos/pull/192)) requires updating the Team Topology docs page, which renders from this copied schema. Part of the [Team-Isolated Gateway Configuration Model](https://github.com/osinfra-io/pt-pneuma/issues/141).

## Validation

`yarn build` succeeds; the SchemaViewer renders the new field.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>