### PR TITLE
Document centralized gateway authentication

### DIFF
--- a/docs/platform-grouping/logos/team-topology.md
+++ b/docs/platform-grouping/logos/team-topology.md
@@ -28,6 +28,63 @@ Each team is defined as an entry in the `teams` map inside a `.tfvars` file unde
 | `branch-protection` | Rules applied to default branch: required reviews, status checks, no force push |
 | `datadog-team` | An observability team in Datadog mirroring the Logos team — owns dashboards and monitors |
 
+## Declaring Mesh Route Auth
+
+Mesh-enabled Kubernetes namespaces can declare external route intent and route auth intent in the same Logos team spec. Logos is the source of truth; Pneuma consumes the resolved data through `module.core_helpers` and renders the Gateway API `HTTPRoute`, Istio `RequestAuthentication`, and Istio `AuthorizationPolicy` resources centrally. Teams should use the [Nomos Agent](/onboarding) to author these changes so the `pt-techne-mcp-server` schema validates the route and auth policy before a PR is opened.
+
+`route_auth_policies` is a map keyed by an existing `routes` entry in the same namespace. Each policy supports:
+
+- `enforced` — Optional boolean. Defaults to `true`, which means fail-closed gateway enforcement.
+- `public_paths` — Optional list of path prefixes that bypass auth. Each path must be under the referenced route path and cannot be `/`.
+- `required_groups` — Optional list of Keycloak groups accepted for the route.
+- `required_roles` — Optional list of Keycloak realm roles accepted for the route.
+
+Enforced policies must include at least one required group or role. Omit `route_auth_policies` only when the route is intentionally unauthenticated, or set `enforced = false` for an explicit public route.
+
+### Example
+
+```hcl
+platform_managed_project = {
+  kubernetes_engine = {
+    dns_subdomain = "ethos"
+
+    namespaces = {
+      "api" = {
+        istio_injection = "enabled"
+
+        routes = {
+          "api" = {
+            path    = "/api"
+            port    = 8080
+            service = "api-service"
+          }
+        }
+
+        route_auth_policies = {
+          "api" = {
+            public_paths    = ["/api/healthz", "/api/readyz"]
+            required_groups = ["st-ethos-developers"]
+            required_roles  = ["ethos-api-reader"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This declaration lets unauthenticated callers reach only the health and readiness paths. All other requests under `/api` must arrive with a valid Keycloak-backed browser session cookie or bearer token and match one of the declared group or role claims.
+
+### Ownership Boundaries
+
+| Owner | Boundary |
+|---|---|
+| App teams | Declare route and auth intent in Logos; own the backend Service and application behavior. |
+| Logos | Stores the reviewed contract for namespaces, routes, and `route_auth_policies`. |
+| Pneuma | Renders and operates the gateway auth resources; RBAC and admission guardrails prevent teams from managing them directly. |
+| Arche | Provides the reusable Keycloak and OAuth2 Proxy modules consumed by Pneuma. |
+| Techne | Provides the schema and Nomos self-serve flow used to validate and submit team intent. |
+
 ## Core Invariants
 
 - Every team definition produces exactly one set of GCP, GitHub, and Datadog resources.

--- a/docs/platform-grouping/pneuma/gateway-auth.md
+++ b/docs/platform-grouping/pneuma/gateway-auth.md
@@ -1,0 +1,141 @@
+---
+sidebar_label: Gateway Auth
+---
+
+# Gateway Auth
+
+Pneuma centralizes external application authentication and authorization at the shared gateway clusters. Stream-aligned teams declare route-level auth intent in Logos; Pneuma turns that contract into Istio and OAuth2 Proxy enforcement at the gateway before traffic reaches workload clusters.
+
+:::tip Architecture Decision Records
+
+This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
+
+:::
+
+## Architecture
+
+Gateway auth is a centralized authn/authz layer on the Pneuma gateway data plane (`gateway-istio`). It combines identity, session validation, JWT validation, and Istio external authorization without requiring app teams to run their own ingress auth stack.
+
+```mermaid
+flowchart LR
+    User([User or client]) --> Armor[Cloud Armor]
+    Armor --> TLS[TLS termination]
+    TLS --> RequestAuth[Istio RequestAuthentication]
+    RequestAuth --> ExtAuthz[OAuth2 Proxy ext_authz]
+    ExtAuthz --> Route[Gateway API HTTPRoute]
+    Route --> Mesh[Mesh mTLS and workload authz]
+    Mesh --> App[Team workload]
+
+    Keycloak[Keycloak OIDC issuer] --> RequestAuth
+    Keycloak --> ExtAuthz
+    Logos[Logos route_auth_policies] --> Pneuma[Pneuma rendering]
+    Pneuma --> RequestAuth
+    Pneuma --> ExtAuthz
+```
+
+## Components
+
+| Component | Owner | Description |
+|---|---|---|
+| Keycloak | Pneuma via Arche | OIDC issuer and IAM layer deployed on gateway clusters by the `pt-pneuma` regional `keycloak` workspace. The `pt-arche-kubernetes-keycloak` module deploys the Helm release and persists state in Cloud SQL PostgreSQL. |
+| OAuth2 Proxy | Pneuma via Arche | Browser session and bearer-token validator deployed by the `pt-pneuma` regional `oauth2-proxy` workspace through `pt-arche-kubernetes-oauth2-proxy`. It is registered in Istio `MeshConfig` as the `oauth2-proxy` ext_authz `ExtensionProvider`. |
+| Istio `RequestAuthentication` | Pneuma | Validates JWTs against Keycloak JWKS at the gateway data plane before authorization decisions are evaluated. |
+| Istio `AuthorizationPolicy` | Pneuma | Uses `action: CUSTOM` and provider `oauth2-proxy` for enforced routes, excluding standard health paths, OAuth2 callback paths, and declared public paths. Claim checks enforce required groups and roles. |
+| Logos `route_auth_policies` | Logos | Source-of-truth team intent keyed by route name. App teams change this contract through Logos, usually with the Nomos self-serve flow. |
+
+## Request Evaluation Order
+
+Every external request follows this order at the gateway:
+
+1. **Cloud Armor** evaluates WAF, rate limiting, and edge protection policy before the request reaches the gateway backend.
+2. **TLS terminates at the gateway** using the shared wildcard certificate and Gateway API listener.
+3. **Istio `RequestAuthentication` validates JWTs** against the Keycloak JWKS on the `gateway-istio` data plane.
+4. **OAuth2 Proxy evaluates ext_authz** for enforced paths, validating browser session cookies or bearer tokens and denying requests that do not satisfy the route policy.
+5. **Gateway API `HTTPRoute` routing** selects the team backend service from Logos-declared route intent.
+6. **Mesh-level mTLS and authorization** protect service-to-service traffic in the workload clusters after the request enters the mesh.
+
+:::warning Fail-closed by default
+
+Enforced auth policies do not fail open. If OAuth2 Proxy or the ext_authz path is unavailable, the gateway denies the request rather than bypassing authorization.
+
+:::
+
+## Team Consumption Model
+
+Teams do not apply Kubernetes auth resources to Pneuma clusters. They declare intent in Logos alongside their route declarations using `route_auth_policies`, a map keyed by an existing route name. Pneuma consumes the resolved Logos outputs through `module.core_helpers` and renders the gateway resources centrally.
+
+Each policy supports:
+
+- `enforced` — Optional boolean. Defaults to `true`; set to `false` only for explicitly public routes.
+- `public_paths` — Optional list of path prefixes that bypass enforcement. Each path must sit under the referenced route path and cannot be `/`.
+- `required_groups` — Optional list of Keycloak group claims accepted for the route.
+- `required_roles` — Optional list of Keycloak realm roles accepted for the route.
+
+Enforced policies require at least one group or role. Use the [Nomos Agent](/onboarding) to author or update the Logos spec; Nomos validates the request against the `pt-techne-mcp-server` schema before opening the change.
+
+## Ownership Boundaries
+
+| Boundary | Responsibility |
+|---|---|
+| App teams | Declare route and auth intent in Logos only. They own application behavior behind the route, but not gateway authn/authz Kubernetes resources. |
+| Logos | Contract and source of truth for teams, namespaces, routes, and `route_auth_policies`. |
+| Pneuma | Central enforcement owner. It renders Keycloak, OAuth2 Proxy, Istio `RequestAuthentication`, Istio `AuthorizationPolicy`, Gateway API routes, RBAC, and admission guardrails. |
+| Arche | Reusable provider modules for Keycloak and OAuth2 Proxy Helm-based deployments. |
+| Techne | Schema tooling and Nomos self-serve agent flow that validate team-auth intent before Logos changes land. |
+| Team repositories | Application code, services, and deployment manifests that receive already-authenticated gateway traffic. |
+
+RBAC and admission guardrails in Pneuma prevent app teams from managing gateway authn/authz resources directly. This keeps all external auth behavior reviewable through Logos and centrally enforceable by Pneuma.
+
+## Operational Expectations
+
+- Unauthenticated requests are rejected at the gateway before routing to a team backend.
+- OAuth2 Proxy validates both browser session cookies and bearer tokens, so browser and API clients use the same centralized policy path.
+- Standard health paths, OAuth2 callback paths, and declared `public_paths` bypass ext_authz; all other enforced paths require a valid identity and matching group or role claim.
+- Keycloak availability and Cloud SQL PostgreSQL persistence are gateway platform concerns owned by Pneuma.
+- Route-auth changes deploy on the next Logos-to-Pneuma pipeline run, the same as route changes.
+
+## Observability
+
+Auth decision logs, ext_authz denials, and gateway access logs are collected in Datadog. Pneuma owns monitors and dashboards for auth failure rate, denial spikes, OAuth2 Proxy health, and Keycloak availability. Teams should use those Datadog surfaces when troubleshooting access denials before escalating to Pneuma.
+
+## Core Invariants
+
+- Auth intent is declared in Logos, not as team-managed Kubernetes resources in Pneuma.
+- Enforced policies fail closed and require at least one allowed group or role.
+- Public bypasses must be scoped below the route path and cannot make an entire host public by using `/`.
+- JWT validation happens at the gateway data plane against Keycloak JWKS before ext_authz policy decisions.
+- Browser cookies and bearer tokens follow the same gateway authorization path.
+
+## Architecture Decision Records
+
+### Centralized Gateway Auth Enforcement
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Pneuma, Logos, Techne</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+External team services need consistent authentication and authorization without every team operating its own ingress auth stack. If each team owned Keycloak clients, OAuth2 Proxy instances, Istio auth policies, and gateway resources directly, the platform would drift into inconsistent fail-open behavior and unclear ownership during incidents.
+
+#### Decision
+
+Centralize authn/authz at Pneuma gateway clusters. Logos remains the contract where teams declare route-auth intent; Pneuma consumes that contract and renders Keycloak, OAuth2 Proxy ext_authz, Istio JWT validation, and Istio authorization policy centrally. Arche packages reusable Helm-based modules, and Techne provides the schema and Nomos authoring flow.
+
+#### Alternatives Considered
+
+- **Team-managed gateway auth resources** — Rejected. Direct Kubernetes ownership would bypass the reviewed Logos contract and make route isolation, fail-closed behavior, and incident ownership inconsistent.
+- **Per-application OAuth2 Proxy sidecars** — Rejected. Duplicates auth infrastructure in every app, complicates upgrades, and does not protect requests before they enter workload clusters.
+- **Application-only authorization** — Rejected. Leaves unauthenticated traffic to reach teams and makes centralized denial observability impossible.
+
+#### Consequences
+
+- Teams get a self-service auth contract without owning gateway internals.
+- Pneuma is the single operational owner for gateway auth availability, denial behavior, and observability.
+- Schema validation in Techne and PR review in Logos become part of the security boundary.
+- Gateway auth outages deny enforced traffic instead of failing open.

--- a/docs/platform-grouping/pneuma/index.md
+++ b/docs/platform-grouping/pneuma/index.md
@@ -9,6 +9,7 @@ Pneuma is the breath of life animating the platform via Kubernetes — orchestra
 
 - **[Cluster Management](./cluster-management.md)**: GKE clusters with autoscaling node pools, Workload Identity, and Fleet enrollment
 - **[Service Mesh](./service-mesh.md)**: Istio with mTLS, traffic management, and Datadog AAP-backed ingress
+- **[Gateway Auth](./gateway-auth.md)**: Centralized Keycloak, OAuth2 Proxy, and Istio auth policy enforcement for external routes
 - **[Certificate Management](./certificate-management.md)**: cert-manager with istio-csr as the mesh CA, issuing all workload mTLS certificates from a self-signed root
 - **[Policy Enforcement](./policy-enforcement.md)**: OPA Gatekeeper constraint templates and audit mode
 - **[Observability](./observability.md)**: Datadog Operator for cluster metrics, traces, and log collection
@@ -42,6 +43,7 @@ Pneuma consumes from Corpus (networking and project infrastructure) and Arche (t
 | Cluster | A GKE Kubernetes cluster deployed to one or more zones within a Corpus project |
 | Constraint | An OPA Gatekeeper policy rule enforced at admission time against incoming Kubernetes resources |
 | Fleet | A GCP construct grouping GKE clusters for unified management and policy |
+| Gateway auth | Centralized authentication and authorization at the Pneuma ingress gateway, generated from Logos `route_auth_policies` |
 | Operator | A Kubernetes controller deployed as an add-on (Datadog Operator, cert-manager) managing its resource lifecycle |
 | Policy | A set of constraints defining the compliance posture for a cluster |
 | Service mesh | The Istio control plane managing mTLS, traffic routing, and observability across all pods |

--- a/docs/platform-grouping/pneuma/observability.md
+++ b/docs/platform-grouping/pneuma/observability.md
@@ -42,6 +42,17 @@ Autodiscovery rules are pre-configured for the following cluster components:
 - **Cilium**: Scrapes Cilium eBPF dataplane metrics from the agent endpoint using OpenMetrics
 - **Envoy (Istio sidecars)**: Scrapes Envoy proxy metrics from the Istio stats endpoint and collects Envoy access logs
 
+## Gateway Auth Observability
+
+Centralized gateway auth emits its operational signals through the same Datadog collection path as the rest of Pneuma:
+
+- **Auth decision logs**: OAuth2 Proxy and Envoy access logs show whether a request was allowed, redirected, or denied.
+- **Denial visibility**: Ext_authz denials and unauthenticated gateway rejections are visible in Datadog logs and dashboards for troubleshooting team access issues.
+- **Health monitoring**: Pneuma monitors OAuth2 Proxy health, Keycloak availability, and auth failure rate so enforced routes remain fail-closed without becoming silent outages.
+- **Token mode coverage**: Browser session-cookie validation and bearer-token validation use the same gateway path, so both client types appear in the gateway auth logs.
+
+Teams should check the Datadog gateway auth dashboards and denial logs before escalating an access issue to Pneuma.
+
 ## Components
 
 | Component | Description |

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -4,11 +4,11 @@ sidebar_label: Service Mesh
 
 # Service Mesh
 
-Istio runs on every GKE cluster as a single multi-cluster mesh via GKE Fleet. It provides mTLS between services, traffic management, and an ingress gateway backed by Cloud Armor WAF and Datadog AAP. Ingress uses the vendor-neutral [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
+Istio runs on every GKE cluster as a single multi-cluster mesh via GKE Fleet. It provides mTLS between services, traffic management, centralized [gateway auth](./gateway-auth.md), and an ingress gateway backed by Cloud Armor WAF and Datadog AAP. Ingress uses the vendor-neutral [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
 
 - **mTLS**: All pod-to-pod traffic is encrypted and authenticated via per-cluster istiod instances
-- **Ingress gateway**: External traffic enters exclusively through pneuma's gateway — a Gateway API `Gateway` reconciled by istiod, backed by MCI global load balancer, Cloud Armor WAF, and Datadog AAP
-- **Routing**: Teams declare route intent in Logos; pneuma renders `HTTPRoute`s with hostnames derived from the team's authoritative DNS zone
+- **Ingress gateway**: External traffic enters exclusively through pneuma's gateway — a Gateway API `Gateway` reconciled by istiod, backed by MCI global load balancer, Cloud Armor WAF, Datadog AAP, and OAuth2 Proxy external authorization
+- **Routing and auth**: Teams declare route intent and auth policy in Logos; Pneuma renders `HTTPRoute`s and Istio auth policies with hostnames derived from the team's authoritative DNS zone
 - **cert-manager**: Istio's built-in CA is replaced by cert-manager via istio-csr for all workload mTLS certificates
 
 :::tip Architecture Decision Records
@@ -23,6 +23,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 |---|---|
 | `istio-control-plane` | istiod deployed via Helm on every cluster — manages traffic policy and mTLS certificate distribution |
 | `gateway` | Gateway API `Gateway` (gatewayClassName `istio`) on pneuma clusters only. istiod auto-provisions the `gateway-istio` data plane; exposed via MCI global and zonal load balancers |
+| `gateway-auth` | Istio `RequestAuthentication` and `AuthorizationPolicy` resources on the gateway data plane — validates Keycloak JWTs, invokes OAuth2 Proxy via ext_authz, and enforces route-scoped group/role claims |
 | `waf-policy` | Cloud Armor security policy on the ingress gateway (OWASP rules, rate limiting, adaptive DDoS) |
 | `http-route` | Gateway API `HTTPRoute` per team host, co-located with the backend `Service` in the team's namespace |
 | `destination-rule` | Istio connection pool and circuit breaker settings per destination |
@@ -67,6 +68,8 @@ Teams declare route intent (`service`, `port`, optional `path`) under a mesh-ena
 
 The shared `Gateway` carries a single catch-all HTTPS listener (no hostname filter, wildcard TLS cert). Route changes take effect on the next pneuma pipeline run.
 
+Teams may also declare `route_auth_policies` keyed by route name. Enforced routes require a valid Keycloak JWT and pass through OAuth2 Proxy external authorization unless the request path is a public path, OAuth2 callback path, or standard health path. Required groups and roles are enforced by Istio `AuthorizationPolicy` checks against validated JWT claims (`groups` and `realm_access.roles`). This keeps route authorization generated from the Logos contract and fail-closed at the gateway. See [Gateway Auth](./gateway-auth.md) for the full request evaluation order, ownership model, and operational expectations.
+
 **Example declaration** (in the team's Logos spec):
 
 ```hcl
@@ -79,6 +82,13 @@ namespaces = {
         path    = "/api"
         port    = 8080
         service = "api-service"
+      }
+    }
+
+    route_auth_policies = {
+      "api" = {
+        public_paths    = ["/api/healthz"]
+        required_groups = ["st-ethos-readers"]
       }
     }
   }
@@ -138,6 +148,7 @@ The `istio-test` workspace deploys a lightweight metadata service into each team
 - mTLS is enforced on every cluster via `PeerAuthentication` in strict mode — no plaintext pod-to-pod traffic.
 - The ingress gateway runs only on pneuma clusters — member clusters have no public endpoint.
 - `HTTPRoute` hostnames are derived from the team's `dns_subdomain` — teams cannot serve traffic on another team's subdomain.
+- Gateway auth is fail-closed: enforced routes require Keycloak JWT validation and OAuth2 Proxy ext_authz; the extension provider does not fail open.
 - Member namespace names carry the team-key prefix (`{team_key}-{namespace}`) — no cross-team endpoint aggregation in the mesh.
 
 ## Architecture Decision Records

--- a/sidebars.js
+++ b/sidebars.js
@@ -43,6 +43,7 @@ const sidebars = {
           items: [
             'platform-grouping/pneuma/cluster-management',
             'platform-grouping/pneuma/service-mesh',
+            'platform-grouping/pneuma/gateway-auth',
             'platform-grouping/pneuma/certificate-management',
             'platform-grouping/pneuma/policy-enforcement',
             'platform-grouping/pneuma/observability',

--- a/src/components/SchemaViewer/team.schema.json
+++ b/src/components/SchemaViewer/team.schema.json
@@ -638,6 +638,13 @@
           "additionalProperties": {
             "$ref": "#/$defs/gkeRoute"
           }
+        },
+        "route_auth_policies": {
+          "description": "Route authentication and authorization intent for this namespace, keyed by an existing route name. Pneuma renders each entry as centralized gateway auth policy on the shared Istio gateway. Enforced policies default to fail-closed and require at least one required group or role.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/gkeRouteAuthPolicy"
+          }
         }
       }
     },
@@ -664,6 +671,83 @@
         "service": {
           "description": "Name of the backend Kubernetes Service in this namespace to route matched traffic to.",
           "type": "string"
+        }
+      }
+    },
+    "gkeRouteAuthPolicy": {
+      "description": "Gateway authentication and authorization intent for a single Logos-declared route.",
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "not": {
+              "required": [
+                "enforced"
+              ],
+              "properties": {
+                "enforced": {
+                  "const": false
+                }
+              }
+            }
+          },
+          "then": {
+            "anyOf": [
+              {
+                "required": [
+                  "required_groups"
+                ],
+                "properties": {
+                  "required_groups": {
+                    "minItems": 1
+                  }
+                }
+              },
+              {
+                "required": [
+                  "required_roles"
+                ],
+                "properties": {
+                  "required_roles": {
+                    "minItems": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "enforced": {
+          "description": "Whether gateway auth is enforced for this route. Defaults to true so routes fail closed unless explicitly made public.",
+          "type": "boolean",
+          "default": true
+        },
+        "public_paths": {
+          "description": "Path prefixes under the referenced route path that bypass gateway auth. Entries cannot be \"/\".",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^/.+",
+            "not": {
+              "const": "/"
+            }
+          }
+        },
+        "required_groups": {
+          "description": "Keycloak group claims accepted for this route when auth is enforced.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_roles": {
+          "description": "Keycloak realm role claims accepted for this route when auth is enforced.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- Add a Pneuma Gateway Auth architecture page covering Keycloak, OAuth2 Proxy ext_authz, Istio JWT validation, fail-closed enforcement, ownership boundaries, and the ordered gateway request evaluation flow.
- Update Logos Team Topology docs and the local schema viewer copy to describe route_auth_policies, validation expectations, Nomos usage, and a realistic HCL example.
- Update Pneuma service mesh, observability, index, and sidebar wiring for the new auth model.

Resolves #106
Parent: osinfra-io/pt-pneuma#142

## Validation
- yarn install --frozen-lockfile --silent
- yarn build
- pre-commit autoupdate --freeze
- pre-commit run -a
- markdownlint command was not installed or configured in package scripts; Docusaurus build covered internal link validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for centralized Gateway authentication and authorization.
  * Documented route authentication policies, enforcement rules, request evaluation, and fail-closed behavior.
  * Added examples for configuring authentication in team specifications.
  * Documented observability, operational expectations, ownership boundaries, and supported authentication components.
  * Added Gateway Auth links and glossary definitions to the platform documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->