### PR TITLE
Document Cloud SQL map and gateway auth policies

### DIFF
--- a/docs/platform-grouping/corpus/data-services.md
+++ b/docs/platform-grouping/corpus/data-services.md
@@ -7,7 +7,7 @@ sidebar_label: Data Services
 Corpus provisions Private Services Access peering for the Shared VPC and Cloud SQL instances in team platform-managed projects, consuming Logos team configuration.
 
 - **Private Services Access**: A reserved IP range and peering connection enable Cloud SQL and Memorystore with private IP from any Shared VPC workload
-- **Cloud SQL**: One PostgreSQL instance per declared region in the team's platform-managed project, with private IP through the Shared VPC peering connection
+- **Cloud SQL**: One PostgreSQL instance per declared instance name and region in the team's platform-managed project, with private IP through the Shared VPC peering connection
 - **Pub/Sub**: No platform prerequisites required; Private Google Access on all subnets covers pod connectivity without NAT
 
 :::tip Architecture Decision Records
@@ -28,19 +28,19 @@ The primary resource is `service-networking-connection` — the VPC peering conn
 
 ### Cloud SQL Instance
 
-`cloud-sql-instance` is a managed PostgreSQL instance provisioned by Corpus in a team's platform-managed project — at most one per declared region. Created via `pt-arche-google-cloud-sql` with private IP through the Shared VPC peering connection (`ipv4_enabled = false`) and SSL enforced (`ssl_mode = "ENCRYPTED_ONLY"`).
+`cloud-sql-instance` is a managed PostgreSQL instance provisioned by Corpus in a team's platform-managed project. Teams declare one or more named instances under `cloud_sql` (keyed by a team-chosen instance name such as `authentik`), and Corpus provisions one instance per declared instance name and region. Created via `pt-arche-google-cloud-sql` with private IP through the Shared VPC peering connection (`ipv4_enabled = false`) and SSL enforced (`ssl_mode = "ENCRYPTED_ONLY"`).
 
 ## Glossary
 
 | Term | Meaning in this context |
 |---|---|
-| `cloud-sql-instance` | A managed PostgreSQL instance per region in the team's platform-managed project, accessible via private IP through the Shared VPC peering connection |
+| `cloud-sql-instance` | A managed PostgreSQL instance per declared instance name and region in the team's platform-managed project, accessible via private IP through the Shared VPC peering connection |
 | `managed-services-ip-range` | A reserved IP range in the host VPC allocated for Google managed services Private Services Access |
 | `service-networking-connection` | The VPC peering connection between the host VPC and Google's managed services network |
 
 ## Core Invariants
 
-- Each team has at most one Cloud SQL instance per declared region — never more than one instance per team per region.
+- Each team declares Cloud SQL instances by name under `cloud_sql`; Corpus provisions at most one instance per declared instance name and region — never more than one per instance name per region.
 - Every Cloud SQL instance has no public IP — private connectivity only, with SSL enforced.
 
 ## Architecture Decision Records
@@ -77,6 +77,6 @@ Stream-aligned teams without a platform-managed project provision their own inst
 #### Consequences
 
 - Cloud SQL and Memorystore Private IP are available to any workload on the Shared VPC after the one-time Corpus PR per environment
-- Teams declare `cloud_sql` in Logos; Corpus provisions the instance in their platform-managed project automatically on the next deployment
+- Teams declare named `cloud_sql` instances in Logos; Corpus provisions each instance in their platform-managed project automatically on the next deployment
 - Stream-aligned teams without a platform-managed project provision their own instances using the Arche module directly
 - The team topology expands to a dedicated data platform team only when shared data infrastructure appears on the roadmap

--- a/docs/platform-grouping/logos/team-topology.md
+++ b/docs/platform-grouping/logos/team-topology.md
@@ -28,6 +28,51 @@ Each team is defined as an entry in the `teams` map inside a `.tfvars` file unde
 | `branch-protection` | Rules applied to default branch: required reviews, status checks, no force push |
 | `datadog-team` | An observability team in Datadog mirroring the Logos team — owns dashboards and monitors |
 
+## Declaring Mesh Route Auth
+
+Mesh-enabled Kubernetes namespaces can declare external route intent and route auth intent in the same Logos team spec. Logos is the source of truth; Pneuma consumes the resolved data through `module.core_helpers` and renders the Gateway API `HTTPRoute`, Istio `RequestAuthentication`, and Istio `AuthorizationPolicy` resources centrally. Teams should use the [Nomos Agent](/onboarding) to author these changes so the `pt-techne-mcp-server` schema validates the route and auth policy before a PR is opened.
+
+`route_auth_policies` is a map keyed by an existing `routes` entry in the same namespace. Each policy selects a `mode` (default `browser`):
+
+- `public` — No authentication. Must declare nothing else.
+- `browser` — Interactive Authentik SSO. Requires at least one `required_groups` or `required_roles`; must not set `audiences`.
+- `api-jwt` — Bearer JWT validation. Requires at least one `audiences` value.
+
+`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated paths under the referenced route path; each must start with `/`, cannot be `/`, and is matched as declared (add a trailing `/*` to exempt a subtree). `required_groups` and `required_roles` reference Authentik group and role claims. See [Gateway Auth](/platform-grouping/pneuma/gateway-auth) for the full enforcement model and ownership boundaries.
+
+```hcl
+platform_managed_project = {
+  kubernetes_engine = {
+    dns_subdomain = "ethos"
+
+    namespaces = {
+      "api" = {
+        istio_injection = "enabled"
+
+        routes = {
+          "api" = {
+            path    = "/api"
+            port    = 8080
+            service = "api-service"
+          }
+        }
+
+        route_auth_policies = {
+          "api" = {
+            mode            = "browser"
+            public_paths    = ["/api/healthz", "/api/readyz"]
+            required_groups = ["st-ethos-developers"]
+            required_roles  = ["ethos-api-reader"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This declaration lets unauthenticated callers reach only the declared health and readiness paths. All other requests under `/api` must arrive with a valid Authentik-backed browser session and, once Authentik application-policy bindings exist, match one of the declared group or role claims.
+
 ## Core Invariants
 
 - Every team definition produces exactly one set of GCP, GitHub, and Datadog resources.

--- a/docs/platform-grouping/logos/team-topology.md
+++ b/docs/platform-grouping/logos/team-topology.md
@@ -36,9 +36,9 @@ Mesh-enabled Kubernetes namespaces can declare external route intent and route a
 
 - `public` — No authentication. Must declare nothing else.
 - `browser` — Interactive Authentik SSO. Requires at least one `required_groups` or `required_roles`; must not set `audiences`.
-- `api-jwt` — Bearer JWT validation. Requires at least one `audiences` value.
+- `api-jwt` — Machine-to-machine bearer JWT validation. Requires at least one `audiences` value.
 
-`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated paths under the referenced route path; each must start with `/`, cannot be `/`, and is matched as declared (add a trailing `/*` to exempt a subtree). `required_groups` and `required_roles` reference Authentik group and role claims. See [Gateway Auth](/platform-grouping/pneuma/gateway-auth) for the full enforcement model and ownership boundaries.
+`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated paths under the referenced route path; each must start with `/`, cannot be `/`, `/*`, or `*` (a route-root or wildcard-only bypass is rejected), and is matched as declared (add a trailing `/*` to a non-root subtree to exempt it, e.g. `/api/healthz/*`). `required_groups` and `required_roles` reference Authentik group and role claims. See [Gateway Auth](/platform-grouping/pneuma/gateway-auth) for the full enforcement model and ownership boundaries.
 
 ```hcl
 platform_managed_project = {
@@ -71,7 +71,7 @@ platform_managed_project = {
 }
 ```
 
-This declaration lets unauthenticated callers reach only the declared health and readiness paths. All other requests under `/api` must arrive with a valid Authentik-backed browser session and, once Authentik application-policy bindings exist, match one of the declared group or role claims.
+This declaration lets unauthenticated callers reach only the declared health and readiness paths. All other requests under `/api` must arrive with a valid Authentik-backed browser session and, once Authentik application-policy bindings exist, satisfy **every** declared claim list: at least one of the `required_groups` **and** at least one of the `required_roles` when both are set (any single value within a list satisfies that list).
 
 ## Core Invariants
 

--- a/docs/platform-grouping/pneuma/gateway-auth.md
+++ b/docs/platform-grouping/pneuma/gateway-auth.md
@@ -1,0 +1,164 @@
+---
+sidebar_label: Gateway Auth
+---
+
+# Gateway Auth
+
+Pneuma centralizes external application authentication and authorization at the shared gateway clusters. Stream-aligned teams declare route-level auth intent in Logos; Pneuma turns that contract into Istio and Authentik enforcement at the gateway before traffic reaches workload clusters.
+
+:::tip Architecture Decision Records
+
+This page includes [Architecture Decision Records](#architecture-decision-records) documenting the key design decisions.
+
+:::
+
+## Architecture
+
+Gateway auth is a centralized authn/authz layer on the Pneuma gateway data plane (`gateway-istio`). It combines a platform-wide identity provider, JWT validation, forward-auth session validation, and Istio external authorization without requiring app teams to run their own ingress auth stack.
+
+Authentik is the single platform-wide identity provider, published at `authentik.<env>.osinfra.io` (production drops the environment segment). It is deployed on the gateway clusters by the `pt-pneuma` regional `authentik` and `authentik-config` workspaces through the `pt-arche-kubernetes-authentik` module, with its state persisted in a Cloud SQL PostgreSQL instance. Authentik's **embedded outpost** provides the Envoy `ext_authz` endpoint used for browser sessions.
+
+```mermaid
+flowchart LR
+    User([User or client]) --> Armor[Cloud Armor WAF]
+    Armor --> TLS[TLS termination]
+    TLS --> RequestAuth[Istio RequestAuthentication]
+    RequestAuth --> Decision{Mode}
+    Decision -->|browser| ExtAuthz[Authentik embedded outpost ext_authz]
+    Decision -->|api-jwt| Deny[Istio native-claim DENY policy]
+    ExtAuthz --> Route[Gateway API HTTPRoute]
+    Deny --> Route
+    Route --> Mesh[Mesh mTLS and workload authz]
+    Mesh --> App[Team workload]
+
+    Authentik[Authentik OIDC issuer] --> RequestAuth
+    Authentik --> ExtAuthz
+    Logos[Logos route_auth_policies] --> Pneuma[Pneuma rendering]
+    Pneuma --> RequestAuth
+    Pneuma --> ExtAuthz
+    Pneuma --> Deny
+```
+
+## Components
+
+| Component | Owner | Description |
+|---|---|---|
+| Authentik | Pneuma via Arche | Platform-wide OIDC issuer and IAM layer deployed on gateway clusters by the `pt-pneuma` regional `authentik` workspace. The `pt-arche-kubernetes-authentik` module deploys the Helm release and persists state in Cloud SQL PostgreSQL. |
+| Authentik embedded outpost | Pneuma via Arche | Forward-auth (`ext_authz`) endpoint for browser sessions, configured by the regional `authentik-config` workspace. It is registered in Istio `MeshConfig` as the `authentik` ext_authz `ExtensionProvider`. |
+| Istio `RequestAuthentication` | Pneuma | `gateway-authentik-jwt` validates JWTs against the Authentik issuer and JWKS at the gateway data plane before authorization decisions are evaluated. |
+| Istio `AuthorizationPolicy` | Pneuma | `browser` routes get an `action: CUSTOM` policy that forwards to the Authentik embedded outpost. `api-jwt` routes get a native-claim `action: DENY` policy that rejects requests lacking a validated principal or a matching `audiences`, `groups`, or `roles` claim. Standard health paths, Authentik callback paths, and declared public paths are excluded. |
+| Logos `route_auth_policies` | Logos | Source-of-truth team intent keyed by route name. App teams change this contract through Logos, usually with the Nomos self-serve flow. |
+
+## Request Evaluation Order
+
+Every external request follows this order at the gateway:
+
+1. **Cloud Armor** evaluates WAF, rate limiting, and edge protection policy before the request reaches the gateway backend.
+2. **TLS terminates at the gateway** using the shared wildcard certificate and Gateway API listener.
+3. **Istio `RequestAuthentication` validates JWTs** against the Authentik JWKS on the `gateway-istio` data plane. Requests carrying a token get a validated request principal; requests without one are unauthenticated.
+4. **Authorization is enforced by mode** — `browser` routes forward to the Authentik embedded outpost via `ext_authz`; `api-jwt` routes are evaluated by a native-claim DENY policy. Health, Authentik callback, and declared public paths are exempt.
+5. **Gateway API `HTTPRoute` routing** selects the team backend service from Logos-declared route intent.
+6. **Mesh-level mTLS and authorization** protect service-to-service traffic in the workload clusters after the request enters the mesh.
+
+:::warning Fail-closed by default
+
+Enforced auth policies do not fail open. An unknown mode or a missing enforcement path is rejected before apply, and if the ext_authz path is unavailable the gateway denies the request rather than bypassing authorization.
+
+:::
+
+## Auth Modes
+
+Each `route_auth_policies` entry selects one of three modes (default `browser`):
+
+| Mode | Purpose | Required fields | Forbidden fields |
+|---|---|---|---|
+| `public` | No authentication — the route is open | none | `audiences`, `public_paths`, `required_groups`, `required_roles` |
+| `browser` | Interactive Authentik SSO for human users | at least one of `required_groups` / `required_roles` | `audiences` |
+| `api-jwt` | Machine-to-machine bearer JWT validation | at least one `audiences` value | none |
+
+- **`browser`** renders a CUSTOM `AuthorizationPolicy` that forwards the request to the Authentik embedded outpost, which authenticates the interactive session. Group and role authorization for `browser` routes is delegated to Authentik application-policy bindings, so a `browser` route is authenticated-only until those bindings exist.
+- **`api-jwt`** renders a `RequestAuthentication` plus a native-claim DENY `AuthorizationPolicy` that rejects any request without a validated JWT and any whose `audiences`, `required_groups`, or `required_roles` claims do not match.
+- **`public`** renders no enforcement.
+
+Claim matching is **OR within a single list** (any one listed value matches) and **AND across lists** (each declared list must be satisfied). Authentik emits flat `groups` and `roles` claims.
+
+## Team Consumption Model
+
+Teams do not apply Kubernetes auth resources to Pneuma clusters. They declare intent in Logos alongside their route declarations using `route_auth_policies`, a map keyed by an existing route name. Pneuma consumes the resolved Logos outputs through `module.core_helpers` and renders the gateway resources centrally.
+
+Each policy supports:
+
+- `mode` — Optional. One of `public`, `browser`, or `api-jwt`. Defaults to `browser`.
+- `audiences` — Required for `api-jwt`, forbidden otherwise. JWT audiences accepted for the route.
+- `public_paths` — Optional list of unauthenticated paths under the referenced route path. Each path must start with `/`, cannot be `/`, and is matched as declared (add a trailing `/*` to exempt a subtree). Not allowed on `public`.
+- `required_groups` — Optional list of Authentik group claims accepted for the route.
+- `required_roles` — Optional list of Authentik role claims accepted for the route.
+
+A `browser` policy must include at least one required group or role; an `api-jwt` policy must include at least one audience. Use the [Nomos Agent](/onboarding) to author or update the Logos spec; Nomos validates the request against the `pt-techne-mcp-server` schema before opening the change.
+
+## Ownership Boundaries
+
+| Boundary | Responsibility |
+|---|---|
+| App teams | Declare route and auth intent in Logos only. They own application behavior behind the route, but not gateway authn/authz Kubernetes resources. |
+| Logos | Contract and source of truth for teams, namespaces, routes, and `route_auth_policies`. |
+| Pneuma | Central enforcement owner. It renders Authentik, the embedded outpost, Istio `RequestAuthentication`, Istio `AuthorizationPolicy`, Gateway API routes, RBAC, and admission guardrails. |
+| Arche | Reusable provider module (`pt-arche-kubernetes-authentik`) for the Authentik Helm-based deployment and configuration. |
+| Techne | Schema tooling and Nomos self-serve agent flow that validate team-auth intent before Logos changes land. |
+| Team repositories | Application code, services, and deployment manifests that receive already-authenticated gateway traffic. |
+
+RBAC and admission guardrails in Pneuma prevent app teams from managing gateway authn/authz resources directly. This keeps all external auth behavior reviewable through Logos and centrally enforceable by Pneuma.
+
+## Operational Expectations
+
+- Unauthenticated requests to enforced routes are rejected at the gateway before routing to a team backend.
+- Browser sessions are validated by the Authentik embedded outpost; API clients present bearer JWTs validated by Istio `RequestAuthentication` and the native-claim DENY policy.
+- Standard health paths, Authentik callback paths (`/outpost.goauthentik.io`), and declared `public_paths` bypass enforcement; all other enforced paths require a valid identity and, for `api-jwt`, matching claims.
+- Authentik availability and Cloud SQL PostgreSQL persistence are gateway platform concerns owned by Pneuma.
+- Route-auth changes deploy on the next Logos-to-Pneuma pipeline run, the same as route changes.
+
+## Observability
+
+Auth decision logs, ext_authz denials, and gateway access logs are collected in Datadog. Pneuma owns monitors and dashboards for auth failure rate, denial spikes, embedded-outpost health, and Authentik availability. Teams should use those Datadog surfaces when troubleshooting access denials before escalating to Pneuma. See [Observability](./observability.md#gateway-auth-observability) for details.
+
+## Core Invariants
+
+- Auth intent is declared in Logos, not as team-managed Kubernetes resources in Pneuma.
+- Enforced modes fail closed; an unknown mode is rejected before apply.
+- `browser` requires at least one allowed group or role; `api-jwt` requires at least one audience.
+- Public bypasses must be scoped below the route path and cannot make an entire host public by using `/`.
+- JWT validation happens at the gateway data plane against the Authentik JWKS before authorization decisions.
+
+## Architecture Decision Records
+
+### Centralized Gateway Auth Enforcement
+
+<table>
+  <thead>
+    <tr><th>Status</th><th>Date</th><th>Deciders</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Accepted ✅</td><td>July 2026</td><td>Pneuma, Logos, Techne</td></tr>
+  </tbody>
+</table>
+
+#### Context and Problem Statement
+
+External team services need consistent authentication and authorization without every team operating its own ingress auth stack. If each team owned identity clients, forward-auth instances, Istio auth policies, and gateway resources directly, the platform would drift into inconsistent fail-open behavior and unclear ownership during incidents.
+
+#### Decision
+
+Centralize authn/authz at Pneuma gateway clusters. Logos remains the contract where teams declare route-auth intent; Pneuma consumes that contract and renders Authentik, the embedded-outpost ext_authz path, Istio JWT validation, and Istio authorization policy centrally. Arche packages the reusable Authentik module, and Techne provides the schema and Nomos authoring flow.
+
+#### Alternatives Considered
+
+- **Team-managed gateway auth resources** — Rejected. Direct Kubernetes ownership would bypass the reviewed Logos contract and make route isolation, fail-closed behavior, and incident ownership inconsistent.
+- **Per-application forward-auth sidecars** — Rejected. Duplicates auth infrastructure in every app, complicates upgrades, and does not protect requests before they enter workload clusters.
+- **Application-only authorization** — Rejected. Leaves unauthenticated traffic to reach teams and makes centralized denial observability impossible.
+
+#### Consequences
+
+- Teams get a self-service auth contract without owning gateway internals.
+- Pneuma is the single operational owner for gateway auth availability, denial behavior, and observability.
+- Schema validation in Techne and PR review in Logos become part of the security boundary.
+- Gateway auth outages deny enforced traffic instead of failing open.

--- a/docs/platform-grouping/pneuma/gateway-auth.md
+++ b/docs/platform-grouping/pneuma/gateway-auth.md
@@ -76,21 +76,21 @@ Each `route_auth_policies` entry selects one of three modes (default `browser`):
 | `browser` | Interactive Authentik SSO for human users | at least one of `required_groups` / `required_roles` | `audiences` |
 | `api-jwt` | Machine-to-machine bearer JWT validation | at least one `audiences` value | none |
 
-- **`browser`** renders a CUSTOM `AuthorizationPolicy` that forwards the request to the Authentik embedded outpost, which authenticates the interactive session. Group and role authorization for `browser` routes is delegated to Authentik application-policy bindings, so a `browser` route is authenticated-only until those bindings exist.
-- **`api-jwt`** renders a `RequestAuthentication` plus a native-claim DENY `AuthorizationPolicy` that rejects any request without a validated JWT and any whose `audiences`, `required_groups`, or `required_roles` claims do not match.
+- **`browser`** renders a CUSTOM `AuthorizationPolicy` that forwards the request to the Authentik embedded outpost, which authenticates the interactive session. Group and role authorization for `browser` routes is delegated to Authentik application-policy bindings. Until the bindings matching the declared `required_groups` / `required_roles` are provisioned in Authentik, a `browser` route is **authenticated-only** — any authenticated user passes and the declared group/role restrictions are not yet enforced. Teams must provision and validate those bindings before relying on group or role restrictions for the route.
+- **`api-jwt`** renders a `RequestAuthentication` plus a native-claim DENY `AuthorizationPolicy` that rejects any request without a validated JWT, or whose JWT `aud`, `groups`, and `roles` claims do not satisfy the configured `audiences`, `required_groups`, and `required_roles` values respectively.
 - **`public`** renders no enforcement.
 
 Claim matching is **OR within a single list** (any one listed value matches) and **AND across lists** (each declared list must be satisfied). Authentik emits flat `groups` and `roles` claims.
 
 ## Team Consumption Model
 
-Teams do not apply Kubernetes auth resources to Pneuma clusters. They declare intent in Logos alongside their route declarations using `route_auth_policies`, a map keyed by an existing route name. Pneuma consumes the resolved Logos outputs through `module.core_helpers` and renders the gateway resources centrally.
+Teams do not apply Kubernetes auth resources to Pneuma clusters. They declare intent in Logos alongside their route declarations using `route_auth_policies`, a map keyed by an existing route name in a **mesh-enabled** namespace (`route_auth_policies` is only valid where `istio_injection = "enabled"` and is rejected on non-mesh namespaces). Pneuma consumes the resolved Logos outputs through `module.core_helpers` and renders the gateway resources centrally.
 
 Each policy supports:
 
 - `mode` — Optional. One of `public`, `browser`, or `api-jwt`. Defaults to `browser`.
 - `audiences` — Required for `api-jwt`, forbidden otherwise. JWT audiences accepted for the route.
-- `public_paths` — Optional list of unauthenticated paths under the referenced route path. Each path must start with `/`, cannot be `/`, and is matched as declared (add a trailing `/*` to exempt a subtree). Not allowed on `public`.
+- `public_paths` — Optional list of unauthenticated paths under the referenced route path. Each path must start with `/`, cannot be `/`, `/*`, or `*` (a route-root or wildcard-only bypass is rejected), and is matched as declared (add a trailing `/*` to a non-root subtree to exempt it, e.g. `/api/healthz/*`). Not allowed on `public`.
 - `required_groups` — Optional list of Authentik group claims accepted for the route.
 - `required_roles` — Optional list of Authentik role claims accepted for the route.
 
@@ -126,7 +126,7 @@ Auth decision logs, ext_authz denials, and gateway access logs are collected in 
 - Auth intent is declared in Logos, not as team-managed Kubernetes resources in Pneuma.
 - Enforced modes fail closed; an unknown mode is rejected before apply.
 - `browser` requires at least one allowed group or role; `api-jwt` requires at least one audience.
-- Public bypasses must be scoped below the route path and cannot make an entire host public by using `/`.
+- Public bypasses must be scoped below the route path and cannot make an entire host public by using `/`, `/*`, or `*`.
 - JWT validation happens at the gateway data plane against the Authentik JWKS before authorization decisions.
 
 ## Architecture Decision Records

--- a/docs/platform-grouping/pneuma/index.md
+++ b/docs/platform-grouping/pneuma/index.md
@@ -9,6 +9,7 @@ Pneuma is the breath of life animating the platform via Kubernetes — orchestra
 
 - **[Cluster Management](./cluster-management.md)**: GKE clusters with autoscaling node pools, Workload Identity, and Fleet enrollment
 - **[Service Mesh](./service-mesh.md)**: Istio with mTLS, traffic management, and Datadog AAP-backed ingress
+- **[Gateway Auth](./gateway-auth.md)**: Centralized Authentik and Istio auth policy enforcement for external routes
 - **[Certificate Management](./certificate-management.md)**: cert-manager with istio-csr as the mesh CA, issuing all workload mTLS certificates from a self-signed root
 - **[Policy Enforcement](./policy-enforcement.md)**: OPA Gatekeeper constraint templates and audit mode
 - **[Observability](./observability.md)**: Datadog Operator for cluster metrics, traces, and log collection
@@ -42,6 +43,7 @@ Pneuma consumes from Corpus (networking and project infrastructure) and Arche (t
 | Cluster | A GKE Kubernetes cluster deployed to one or more zones within a Corpus project |
 | Constraint | An OPA Gatekeeper policy rule enforced at admission time against incoming Kubernetes resources |
 | Fleet | A GCP construct grouping GKE clusters for unified management and policy |
+| Gateway auth | Centralized authentication and authorization at the Pneuma ingress gateway, generated from Logos `route_auth_policies` |
 | Operator | A Kubernetes controller deployed as an add-on (Datadog Operator, cert-manager) managing its resource lifecycle |
 | Policy | A set of constraints defining the compliance posture for a cluster |
 | Service mesh | The Istio control plane managing mTLS, traffic routing, and observability across all pods |

--- a/docs/platform-grouping/pneuma/observability.md
+++ b/docs/platform-grouping/pneuma/observability.md
@@ -42,6 +42,17 @@ Autodiscovery rules are pre-configured for the following cluster components:
 - **Cilium**: Scrapes Cilium eBPF dataplane metrics from the agent endpoint using OpenMetrics
 - **Envoy (Istio sidecars)**: Scrapes Envoy proxy metrics from the Istio stats endpoint and collects Envoy access logs
 
+## Gateway Auth Observability
+
+Centralized gateway auth emits its operational signals through the same Datadog collection path as the rest of Pneuma:
+
+- **Auth decision logs**: Authentik and Envoy access logs show whether a request was allowed, redirected, or denied.
+- **Denial visibility**: Ext_authz denials and unauthenticated gateway rejections are visible in Datadog logs and dashboards for troubleshooting team access issues.
+- **Health monitoring**: Pneuma monitors the Authentik embedded outpost health, Authentik availability, and auth failure rate so enforced routes remain fail-closed without becoming silent outages.
+- **Mode coverage**: `browser` forward-auth sessions and `api-jwt` bearer-token validation both traverse the gateway path, so both client types appear in the gateway auth logs.
+
+Teams should check the Datadog gateway auth dashboards and denial logs before escalating an access issue to Pneuma.
+
 ## Components
 
 | Component | Description |

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -139,7 +139,13 @@ For any declared route, a team may attach a **gateway auth policy** so pneuma en
 | `browser` | Interactive Authentik SSO for human users | at least one of `required_groups` / `required_roles` | `audiences` |
 | `api-jwt` | Machine-to-machine bearer JWT validation | at least one `audiences` value | none |
 
-`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated sub-paths under the route's `path` prefix — each must start with `/`, must not be `/`, and must fall under the route path. `required_groups` and `required_roles` reference Authentik identity groups and application roles carried in the token claims.
+`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated sub-paths under the route's `path` prefix — each must start with `/`, must not be `/`, and must fall under the route path. Entries are matched **as declared**: `/api/healthz` exempts only that exact path, so to exempt a subtree add a trailing wildcard (`/api/healthz/*`). A root or wildcard-only entry (`/`, `/*`, `*`) is rejected because it would exempt the whole route. `required_groups` and `required_roles` reference Authentik identity groups and application roles carried in the token claims.
+
+**Claim and path matching semantics:**
+
+- **Non-empty lists.** Logos rejects an empty `required_groups`/`required_roles` on a `browser` policy and an empty `audiences` on an `api-jwt` policy, so an enforced route always has at least one principal to match.
+- **OR within a list, AND across lists.** A request satisfies a single claim list if it carries **any one** of the listed values (OR). When more than one claim type is declared (e.g. `audiences` plus `required_roles` on an `api-jwt` route), the request must satisfy **each** list (AND).
+- **Route `path` is a prefix.** A route with `path = "/api"` matches `/api` and everything under it; a route that omits `path` defaults to `/` and matches all paths under the host. Enforcement covers the whole prefix except the declared `public_paths` and pneuma's built-in exemptions (Authentik callback and health-check paths).
 
 **Example declaration** (in the team's Logos spec):
 
@@ -167,7 +173,7 @@ namespaces = {
 }
 ```
 
-Pneuma renders `browser` policies as a forward-auth `AuthorizationPolicy` (Envoy `ext_authz` to the Authentik embedded outpost) plus a native-claim authorization check for the declared groups/roles, and `api-jwt` policies as a `RequestAuthentication` + `AuthorizationPolicy` validating the bearer token audience. `public` routes and any declared `public_paths` are excluded from enforcement.
+Pneuma renders `browser` policies as a forward-auth `AuthorizationPolicy` (Envoy `ext_authz` to the Authentik embedded outpost) that authenticates the interactive session; group and role authorization for `browser` routes is delegated to Authentik application-policy bindings, so a `browser` route is authenticated-only until those bindings exist. `api-jwt` policies render a `RequestAuthentication` plus a native-claim DENY `AuthorizationPolicy` that rejects any request without a validated JWT and any whose `audiences`, `required_groups`, or `required_roles` claims do not match. `public` routes and any declared `public_paths` are excluded from enforcement.
 
 ### End-to-End Validation
 

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -4,11 +4,11 @@ sidebar_label: Service Mesh
 
 # Service Mesh
 
-Istio runs on every GKE cluster as a single multi-cluster mesh via GKE Fleet. It provides mTLS between services, traffic management, and an ingress gateway backed by Cloud Armor WAF and Datadog AAP. Ingress uses the vendor-neutral [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
+Istio runs on every GKE cluster as a single multi-cluster mesh via GKE Fleet. It provides mTLS between services, traffic management, centralized [gateway auth](./gateway-auth.md), and an ingress gateway backed by Cloud Armor WAF and Datadog AAP. Ingress uses the vendor-neutral [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/).
 
 - **mTLS**: All pod-to-pod traffic is encrypted and authenticated via per-cluster istiod instances
-- **Ingress gateway**: External traffic enters exclusively through pneuma's gateway — a Gateway API `Gateway` reconciled by istiod, backed by MCI global load balancer, Cloud Armor WAF, and Datadog AAP
-- **Routing**: Teams declare route intent in Logos; pneuma renders `HTTPRoute`s with hostnames derived from the team's authoritative DNS zone
+- **Ingress gateway**: External traffic enters exclusively through pneuma's gateway — a Gateway API `Gateway` reconciled by istiod, backed by MCI global load balancer, Cloud Armor WAF, Datadog AAP, and Authentik external authorization
+- **Routing and auth**: Teams declare route intent and auth policy in Logos; pneuma renders `HTTPRoute`s and Istio auth policies with hostnames derived from the team's authoritative DNS zone
 - **cert-manager**: Istio's built-in CA is replaced by cert-manager via istio-csr for all workload mTLS certificates
 
 :::tip Architecture Decision Records
@@ -23,6 +23,7 @@ This page includes [Architecture Decision Records](#architecture-decision-record
 |---|---|
 | `istio-control-plane` | istiod deployed via Helm on every cluster — manages traffic policy and mTLS certificate distribution |
 | `gateway` | Gateway API `Gateway` (gatewayClassName `istio`) on pneuma clusters only. istiod auto-provisions the `gateway-istio` data plane; exposed via MCI global and zonal load balancers |
+| `gateway-auth` | Istio `RequestAuthentication` and `AuthorizationPolicy` resources on the gateway data plane — validates Authentik JWTs, forwards `browser` routes to the Authentik embedded outpost via ext_authz, and enforces route-scoped claims for `api-jwt` routes. See [Gateway Auth](./gateway-auth.md) |
 | `waf-policy` | Cloud Armor security policy on the ingress gateway (OWASP rules, rate limiting, adaptive DDoS) |
 | `http-route` | Gateway API `HTTPRoute` per team host, co-located with the backend `Service` in the team's namespace |
 | `destination-rule` | Istio connection pool and circuit breaker settings per destination |
@@ -174,6 +175,8 @@ namespaces = {
 ```
 
 Pneuma renders `browser` policies as a forward-auth `AuthorizationPolicy` (Envoy `ext_authz` to the Authentik embedded outpost) that authenticates the interactive session; group and role authorization for `browser` routes is delegated to Authentik application-policy bindings, so a `browser` route is authenticated-only until those bindings exist. `api-jwt` policies render a `RequestAuthentication` plus a native-claim DENY `AuthorizationPolicy` that rejects any request without a validated JWT and any whose `audiences`, `required_groups`, or `required_roles` claims do not match. `public` routes and any declared `public_paths` are excluded from enforcement.
+
+See [Gateway Auth](./gateway-auth.md) for the full request evaluation order, component ownership, and operational expectations.
 
 ### End-to-End Validation
 

--- a/docs/platform-grouping/pneuma/service-mesh.md
+++ b/docs/platform-grouping/pneuma/service-mesh.md
@@ -129,6 +129,46 @@ spec:
    kubectl get httproute -n st-ethos-api api-ethos -o yaml
    ```
 
+### Gateway Auth Policies
+
+For any declared route, a team may attach a **gateway auth policy** so pneuma enforces authentication and authorization at the shared gateway through Authentik. Policies are declared under `route_auth_policies`, keyed by the matching route name, and may only be set on mesh-enabled namespaces. Each policy selects one of three **modes** (default `browser`):
+
+| Mode | Purpose | Required fields | Forbidden fields |
+|---|---|---|---|
+| `public` | No authentication — the route is open | none | `audiences`, `public_paths`, `required_groups`, `required_roles` |
+| `browser` | Interactive Authentik SSO for human users | at least one of `required_groups` / `required_roles` | `audiences` |
+| `api-jwt` | Machine-to-machine bearer JWT validation | at least one `audiences` value | none |
+
+`public_paths` (allowed on `browser` and `api-jwt`) list unauthenticated sub-paths under the route's `path` prefix — each must start with `/`, must not be `/`, and must fall under the route path. `required_groups` and `required_roles` reference Authentik identity groups and application roles carried in the token claims.
+
+**Example declaration** (in the team's Logos spec):
+
+```hcl
+namespaces = {
+  "api" = {
+    istio_injection = "enabled"
+
+    route_auth_policies = {
+      "api" = {
+        mode            = "browser"
+        public_paths    = ["/api/healthz"]
+        required_groups = ["platform-engineers"]
+      }
+    }
+
+    routes = {
+      "api" = {
+        path    = "/api"
+        port    = 8080
+        service = "api-service"
+      }
+    }
+  }
+}
+```
+
+Pneuma renders `browser` policies as a forward-auth `AuthorizationPolicy` (Envoy `ext_authz` to the Authentik embedded outpost) plus a native-claim authorization check for the declared groups/roles, and `api-jwt` policies as a `RequestAuthentication` + `AuthorizationPolicy` validating the bearer token audience. `public` routes and any declared `public_paths` are excluded from enforcement.
+
 ### End-to-End Validation
 
 The `istio-test` workspace deploys a lightweight metadata service into each team's prefixed istio-test namespace (`pt-pneuma-istio-test`, `pt-kryptos-istio-test`, etc.). A validation script checks every global and zonal endpoint, confirming the returned cluster name matches the expected team and zone.

--- a/sidebars.js
+++ b/sidebars.js
@@ -43,6 +43,7 @@ const sidebars = {
           items: [
             'platform-grouping/pneuma/cluster-management',
             'platform-grouping/pneuma/service-mesh',
+            'platform-grouping/pneuma/gateway-auth',
             'platform-grouping/pneuma/certificate-management',
             'platform-grouping/pneuma/policy-enforcement',
             'platform-grouping/pneuma/observability',

--- a/src/components/SchemaViewer/team.schema.json
+++ b/src/components/SchemaViewer/team.schema.json
@@ -136,7 +136,11 @@
       "additionalProperties": false,
       "properties": {
         "cloud_sql": {
-          "$ref": "#/$defs/cloudSQL"
+          "description": "Cloud SQL instances keyed by team-chosen instance name (e.g. authentik). A team may declare multiple instances.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/cloudSQL"
+          }
         },
         "enable_datadog": {
           "description": "Enable Datadog integration for the platform-managed project.",
@@ -458,7 +462,7 @@
       }
     },
     "cloudSQL": {
-      "description": "Cloud SQL instance configuration. pt-corpus provisions one instance per declared region using the pt-arche-google-cloud-sql module. Each instance receives a private IP address through the Shared VPC peering connection managed by pt-corpus.",
+      "description": "Cloud SQL instance configuration. pt-corpus provisions one instance per declared region using the pt-arche-google-cloud-sql module. The instance name is the map key under cloud_sql. Each instance receives a private IP address through the Shared VPC peering connection managed by pt-corpus.",
       "type": "object",
       "additionalProperties": false,
       "required": [

--- a/src/components/SchemaViewer/team.schema.json
+++ b/src/components/SchemaViewer/team.schema.json
@@ -636,6 +636,17 @@
           ],
           "default": "disabled"
         },
+        "route_auth_policies": {
+          "description": "Gateway auth policy intent for namespace routes, keyed by an existing route name. Pneuma renders each entry as gateway authentication and authorization policy for the matching route. Policies may only be declared on mesh-enabled namespaces (istio_injection = enabled).",
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/gkeRouteAuthPolicy"
+          },
+          "default": {}
+        },
         "routes": {
           "description": "HTTP route intent for this namespace, keyed by route name. Pneuma renders each entry as a Gateway API HTTPRoute on the shared Istio gateway, serving the team's <subdomain>.osinfra.io host at the route's path prefix from the named Service. Routes may only be declared on mesh-enabled namespaces (istio_injection = enabled).",
           "type": "object",
@@ -668,6 +679,69 @@
         "service": {
           "description": "Name of the backend Kubernetes Service in this namespace to route matched traffic to.",
           "type": "string"
+        }
+      }
+    },
+    "gkeRouteAuthPolicy": {
+      "description": "Gateway authentication and authorization policy intent for a namespace route.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "audiences": {
+          "description": "JWT audiences accepted for this route. Values must be non-empty and must not contain whitespace.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^\\S+$"
+          }
+        },
+        "mode": {
+          "description": "Gateway auth mode for this route. Defaults to browser.",
+          "type": "string",
+          "enum": [
+            "public",
+            "browser",
+            "api-jwt"
+          ],
+          "default": "browser"
+        },
+        "public_paths": {
+          "description": "Unauthenticated URL paths under the route path prefix. Each path must start with /, must not be /, and must not contain whitespace.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string",
+            "pattern": "^/\\S+$",
+            "not": {
+              "const": "/"
+            }
+          }
+        },
+        "required_groups": {
+          "description": "Identity groups allowed to access the route. Values must be non-empty and must not contain whitespace.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^\\S+$"
+          }
+        },
+        "required_roles": {
+          "description": "Application roles allowed to access the route. Values must be non-empty and must not contain whitespace.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^\\S+$"
+          }
         }
       }
     },


### PR DESCRIPTION
Synchronizes the docs-site schema copy and the Corpus Data Services page with the updated pt-logos `platform_managed_project.cloud_sql` shape (single object → `map(object)` keyed by a team-chosen instance name such as `authentik`). Teams can now declare multiple Cloud SQL instances.

## Changes
- `src/components/SchemaViewer/team.schema.json`: `cloud_sql` becomes an object with `additionalProperties` referencing the existing `cloudSQL` definition (mirrors the canonical schema in pt-techne-mcp-server). This copy feeds the onboarding PromptBuilder field hints.
- `docs/platform-grouping/corpus/data-services.md`: prose, glossary, and core invariants updated to describe per-named-instance provisioning.

Scoped strictly to Cloud SQL — the separate `route_auth_policies` schema work is unaffected.

---

Also documents gateway auth policies: a new Gateway Auth Policies section on the pneuma service-mesh page and the `route_auth_policies` definition in the SchemaViewer team schema (synced byte-for-byte from the pt-techne-mcp-server canonical schema).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Cloud SQL provisions one PostgreSQL instance for each declared instance name and region.
  * Added comprehensive gateway authentication guidance for browser SSO, API JWT, and public access modes.
  * Documented route configuration, validation, claim matching, unauthenticated paths, enforcement behavior, and operational responsibilities.
  * Added guidance for declaring route authentication in team specifications.
  * Added gateway authentication observability guidance, including dashboards, denial logs, and health monitoring.
  * Added the Gateway Auth page to the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->